### PR TITLE
Bytter googleapis med google-auth-library og @googleapis/drive

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,11 +11,12 @@
   "license": "ISC",
   "dependencies": {
     "@googleapis/docs": "^2.0.0",
+    "@googleapis/drive": "^4.0.2",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
-    "google-spreadsheet": "^3.3.0",
-    "googleapis": "^110.0.0"
+    "google-auth-library": "^8.7.0",
+    "google-spreadsheet": "^3.3.0"
   }
 }

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -2,26 +2,38 @@ lockfileVersion: 5.4
 
 specifiers:
   '@googleapis/docs': ^2.0.0
+  '@googleapis/drive': ^4.0.2
   body-parser: ^1.20.0
   cors: ^2.8.5
   dotenv: ^16.0.2
   express: ^4.18.1
+  google-auth-library: ^8.7.0
   google-spreadsheet: ^3.3.0
-  googleapis: ^110.0.0
 
 dependencies:
   '@googleapis/docs': 2.0.0
+  '@googleapis/drive': 4.0.2
   body-parser: 1.20.1
   cors: 2.8.5
   dotenv: 16.0.3
   express: 4.18.2
+  google-auth-library: 8.7.0
   google-spreadsheet: 3.3.0
-  googleapis: 110.0.0
 
 packages:
 
   /@googleapis/docs/2.0.0:
     resolution: {integrity: sha512-TtQcwIUhBGc4ftr3XChNcXaXUSwZtZJo6HlOQ95Qjq1gsImXuPOAEKfjPhIsN0xlea9WOutC6ZT7kNWuOK+3CA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      googleapis-common: 6.0.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@googleapis/drive/4.0.2:
+    resolution: {integrity: sha512-NBD2wwkK0iVm5le1YqqDPCgUWl4aeEFIZPciiIIKYBz6kpNtdObj5uHDrtGRUxNzqsUUtYbV9FD1743B8jRZUQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       googleapis-common: 6.0.4
@@ -429,17 +441,6 @@ packages:
       qs: 6.11.0
       url-template: 2.0.8
       uuid: 9.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /googleapis/110.0.0:
-    resolution: {integrity: sha512-k6de3PGsdFEBULMiFwPYCKOBljDTDvHD3YGe/OFqe8Ot0lYQPL8QV1qjxjrPWiE/Ftf0Ar2v4DNES66jLfSO7w==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      google-auth-library: 8.7.0
-      googleapis-common: 6.0.4
     transitivePeerDependencies:
       - encoding
       - supports-color

--- a/api/utils/doc-utils.js
+++ b/api/utils/doc-utils.js
@@ -1,16 +1,16 @@
-const { google } = require('googleapis');
-const docs = require('@googleapis/docs');
+const { JWT } = require('google-auth-library');
+const { docs } = require('@googleapis/docs');
 const { getFileIdsInFolder } = require('./drive-utils');
 
 const scopes = ['https://www.googleapis.com/auth/documents.readonly'];
-const jwt = new google.auth.JWT(
+const jwt = new JWT(
   process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
   null,
   process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
   scopes
 );
 
-const client = docs.docs({ version: 'v1', auth: jwt });
+const docsClient = docs({ version: 'v1', auth: jwt });
 
 const getFirstOfTextType = (contentArray, styleType) => {
   for (const content of contentArray) {
@@ -50,7 +50,7 @@ const getImageUrl = (inlineObjects) => {
 };
 
 const getDocument = async (documentId) => {
-  const document = await client.documents.get({
+  const document = await docsClient.documents.get({
     documentId,
   });
 

--- a/api/utils/drive-utils.js
+++ b/api/utils/drive-utils.js
@@ -1,24 +1,25 @@
-const { google } = require('googleapis');
+const { JWT } = require('google-auth-library');
+const { drive } = require('@googleapis/drive');
 
 const scopes = ['https://www.googleapis.com/auth/drive.readonly'];
-const jwt = new google.auth.JWT(
+const jwt = new JWT(
   process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
   null,
   process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
   scopes
 );
 
-const drive = google.drive({ version: 'v3', auth: jwt });
+const driveClient = drive({ version: 'v3', auth: jwt });
 
 const exportFileAsHtml = async (fileId) => {
-  return await drive.files.export({
+  return await driveClient.files.export({
     fileId,
     mimeType: 'text/html',
   });
 };
 
 const getFileIdsInFolder = async (folderId) => {
-  const folder = await drive.files.list({
+  const folder = await driveClient.files.list({
     q: `'${folderId}' in parents and trashed=false`,
   });
   return folder.data.files.map((file) => file.id);


### PR DESCRIPTION
Autentisering gjøres når gjennom `google-auth-library` med JWT i tråd med https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest. Tidligere ble dette gjort ved `google.auth.JWT` fra googleapis, helheten av Googles NodeJS-klient.