### PR TITLE
Refererer til ressurser i public med /

### DIFF
--- a/src/components/common/header/header.tsx
+++ b/src/components/common/header/header.tsx
@@ -20,7 +20,7 @@ const Header = (): JSX.Element => {
       <Navbar dark expand="md" className={styles.navbar}>
         <NavbarToggler onClick={toggleNav} />
         <NavbarBrand className="mr-auto" href="/">
-          <img src="fagord-logo240.png" height="70" width="150" alt="Fagord" />
+          <img src="/fagord-logo240.png" height="70" width="150" alt="Fagord" />
         </NavbarBrand>
         <NavbarToggler onClick={toggleSearch} className={styles.search}>
           <span className="fa fa-search" />


### PR DESCRIPTION
Vite gir følgende instrukser: files in the public directory are served at the root path. Instead of /public/fagord-logo240.png, use /fagord-logo240.png. Gjør derfor dette for å tegne logo i toppmenyen.