### PR TITLE
Flytter Vercel Analytics til index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       src="https://kit.fontawesome.com/aff1df517b.js"
       crossorigin="anonymous"
     ></script>
+    <script defer src="/_vercel/insights/script.js"></script>
 
     <title>Fagord</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@popperjs/core": "^2.11.6",
     "@tanstack/react-query": "^4.24.4",
     "@tanstack/react-query-devtools": "^4.24.4",
-    "@vercel/analytics": "^0.1.11",
     "bootstrap": "^5.2.3",
     "bootstrap-social": "^5.1.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,6 @@ specifiers:
   '@types/sanitize-html': ^2.8.0
   '@typescript-eslint/eslint-plugin': ^5.0.0
   '@typescript-eslint/parser': ^5.50.0
-  '@vercel/analytics': ^0.1.11
   '@vitejs/plugin-react-swc': ^3.1.0
   bootstrap: ^5.2.3
   bootstrap-social: ^5.1.1
@@ -54,7 +53,6 @@ dependencies:
   '@popperjs/core': 2.11.6
   '@tanstack/react-query': 4.24.4_biqbaboplfbrettd7655fr4n2y
   '@tanstack/react-query-devtools': 4.24.4_pkeil6ml7pq7xvil3imldjs2sa
-  '@vercel/analytics': 0.1.11_react@18.2.0
   bootstrap: 5.2.3_@popperjs+core@2.11.6
   bootstrap-social: 5.1.1
   lodash: 4.17.21
@@ -1255,14 +1253,6 @@ packages:
       '@typescript-eslint/types': 5.50.0
       eslint-visitor-keys: 3.3.0
     dev: true
-
-  /@vercel/analytics/0.1.11_react@18.2.0:
-    resolution: {integrity: sha512-mj5CPR02y0BRs1tN3oZcBNAX9a8NxsIUl9vElDPcqxnMfP0RbRc9fI9Ud7+QDg/1Izvt5uMumsr+6YsmVHcyuw==}
-    peerDependencies:
-      react: ^16.8||^17||^18
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /@vitejs/plugin-react-swc/3.1.0_vite@4.1.0:
     resolution: {integrity: sha512-xnDULNrkEbtTtRNnMPp+RsuIuIbk1JJV0xY7irchYyv9JJS4uvmc1EYip+qyrnkcX7TQ9c8vCS3AmkQqADI0Fw==}

--- a/src/fagord-main.tsx
+++ b/src/fagord-main.tsx
@@ -5,12 +5,9 @@ import { Router } from './components/router/router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { inject } from '@vercel/analytics';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-social/bootstrap-social.css';
 import './index.css';
-
-inject();
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Flytter Vercel Analytics til index.html, fordi inject fikk dev til å krasje. Klarte heller ikke å hjemme skriptet bak en betingelse om at `process.env.NODE_ENV` eller `import.meta.env.mode` skulle være ulik `"development"`.