### PR TITLE
Søkefelt gir forslag med oversettelse

### DIFF
--- a/src/components/about-page/team.ts
+++ b/src/components/about-page/team.ts
@@ -19,6 +19,6 @@ export const team: Person[] = [
     email: 'simen.ringdahl@gmail.com',
     linkedin: 'simen-ringdahl-01b237159',
     description:
-      'Simen har mastergrad i Nanoteknologi, ledet konferansen INASCON i 2018, tilbrakte et år på Stanford University, og var studentrepresentant i NTNU-styret et år etter endt studium. Han jobber nå som dataanalytiker hos Aker Carbon Capture.',
+      'Simen har mastergrad i Nanoteknologi, ledet konferansen INASCON i 2018, tilbrakte et år på Stanford University, og var studentrepresentant i NTNU-styret et år etter endt studium. Han jobber nå som dataanalytiker hos Gritera.',
   },
 ];

--- a/src/components/common/header/header.module.css
+++ b/src/components/common/header/header.module.css
@@ -11,6 +11,10 @@
 }
 
 .search {
-  width: 56px;
-  height: 40px;
+  flex-basis: 0 !important;
+  flex-grow: 0 !important;
+}
+
+.search-field {
+  margin: 8px 16px;
 }

--- a/src/components/common/header/header.tsx
+++ b/src/components/common/header/header.tsx
@@ -10,6 +10,7 @@ import {
 import SearchBar from '../search-bar/search-bar';
 import useToggle from '../../utils/use-toggle';
 import styles from './header.module.css';
+import { NavLinks } from './nav-links';
 
 const Header = (): JSX.Element => {
   const [isNavOpen, toggleNav, setIsNavOpen] = useToggle(false);
@@ -17,7 +18,7 @@ const Header = (): JSX.Element => {
 
   return (
     <>
-      <Navbar dark expand="md" className={styles.navbar}>
+      <Navbar dark expand="lg" className={styles.navbar}>
         <NavbarToggler onClick={toggleNav} />
         <NavbarBrand className="mr-auto" href="/hjem">
           <img src="/fagord-logo240.png" height="70" width="150" alt="Fagord" />
@@ -32,36 +33,20 @@ const Header = (): JSX.Element => {
               setIsNavOpen(false);
             }}
           >
-            <NavItem>
-              <NavLink className="nav-link text-nowrap" to="/hjem">
-                <span className={'fa fa-home fa-lg ' + styles.icon} /> Hjem
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink className="nav-link text-nowrap" to="/termliste">
-                <span className={'fa fa-book fa-lg ' + styles.icon} /> Termliste
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink className="nav-link text-nowrap" to="/ny-term">
-                <span className={'fa fa-lightbulb fa-lg ' + styles.icon} /> Ny
-                term
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink className="nav-link text-nowrap" to="/om-oss">
-                <span className={'fa fa-info fa-lg ' + styles.icon} /> Om oss
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink className="nav-link text-nowrap" to="/kontakt">
-                <span className={'fa fa-address-card ' + styles.icon} /> Kontakt
-              </NavLink>
-            </NavItem>
+            {NavLinks.map((navItem) => (
+              <NavItem key={navItem.address}>
+                <NavLink className="nav-link text-nowrap" to={navItem.address}>
+                  <span
+                    className={'fa fa-lg ' + navItem.icon + ' ' + styles.icon}
+                  />{' '}
+                  {navItem.text}
+                </NavLink>
+              </NavItem>
+            ))}
           </Nav>
         </Collapse>
-        <Collapse isOpen={isSearchOpen} navbar>
-          <Nav className="ml-auto" navbar>
+        <Collapse isOpen={isSearchOpen} navbar className="ms-auto">
+          <Nav navbar>
             <NavItem>
               <SearchBar />
             </NavItem>

--- a/src/components/common/header/nav-links.ts
+++ b/src/components/common/header/nav-links.ts
@@ -1,0 +1,29 @@
+import { NavItem } from '../../../types/nav-item';
+
+export const NavLinks: NavItem[] = [
+  {
+    address: '/hjem',
+    icon: 'fa-home',
+    text: 'Hjem',
+  },
+  {
+    address: '/termliste',
+    icon: 'fa-book',
+    text: 'Termliste',
+  },
+  {
+    address: '/ny-term',
+    icon: 'fa-lightbulb',
+    text: 'Ny term',
+  },
+  {
+    address: '/om-oss',
+    icon: 'fa-info',
+    text: 'Om oss',
+  },
+  {
+    address: '/kontakt',
+    icon: 'fa-address-card',
+    text: 'Kontakt',
+  },
+];

--- a/src/components/common/search-bar/example_terms.ts
+++ b/src/components/common/search-bar/example_terms.ts
@@ -1,0 +1,49 @@
+import { Term } from "../../../types/term";
+
+const terms: Term[] = [
+    {
+      _id: 'cortex_sub',
+      en: 'cortex',
+      nb: 'hjernebark',
+      nn: 'hjernebork',
+      variants: [
+        { term: 'hjernebark', dialect: 'nb', votes: 1 },
+        { term: 'hjernebork', dialect: 'nn', votes: 1 },
+      ],
+      field: 'Biologi',
+      subfield: 'Nevrovitenskap',
+      pos: 'substantiv',
+      definition:
+        'Ytre, grå substans av nerveceller som dekker overflata på hjernen',
+    },
+    {
+      _id: 'archaea_sub',
+      en: 'archaea',
+      nb: 'arkebakterier',
+      nn: 'arkebakteriar',
+      variants: [
+        { term: 'arkebakterier', dialect: 'nb', votes: 1 },
+        { term: 'arkebakteriar', dialect: 'nn', votes: 1 },
+      ],
+      field: 'Biologi',
+      subfield: 'Mikrobiologi',
+      pos: 'substantiv',
+      definition:
+        'Mikroskopiske, encellede, prokaryote organismer som utseendemessig likner bakterier, men har andre biokjemiske komponenter i cellevegg og ulik form og størrelse på ribosomene.',
+    },
+    {
+      _id: 'benchmark_sub',
+      en: 'benchmark',
+      nb: 'ytelsestest',
+      nn: 'ytingstest',
+      variants: [
+        { term: 'ytelsestest', dialect: 'nb', votes: 1 },
+        { term: 'ytingstest', dialect: 'nn', votes: 1 },
+      ],
+      field: 'IT',
+      subfield: 'Programvare',
+      pos: 'substantiv',
+      definition:
+        'Testing for å måle ytelsen til et programvareprodukt. Måling av systemets svartider eller testing av systemets kapasitet under gitte krav til svartider.',
+    },
+  ];

--- a/src/components/common/search-bar/search-bar.module.css
+++ b/src/components/common/search-bar/search-bar.module.css
@@ -1,6 +1,29 @@
 .search {
-  width: 250px;
-  max-width: 95vw;
+  width: 100%;
+  min-width: 250px;
+  max-width: 400px;
   color: #000;
   margin: auto;
+}
+
+@media screen and (min-width: 1024px) {
+  .search {
+    min-width: 350px;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .search {
+    min-width: 400px;
+  }
+}
+
+.item-title {
+  color: #090a3c;
+  margin-bottom: 5px;
+}
+
+.item-subtitle {
+  font-size: 14px;
+  color: #090a3c80;
 }

--- a/src/components/term-page/term-component/translation-card/translation-card.module.css
+++ b/src/components/term-page/term-component/translation-card/translation-card.module.css
@@ -1,6 +1,6 @@
 .card {
   background-color: var(--color-dark-blue) !important;
-  color: floralwhite;
+  color: floralwhite !important;
   border-color: #808080 !important;
   border-style: solid;
   border-width: 0.5px;

--- a/src/components/term-page/term-component/translation-card/translation-card.tsx
+++ b/src/components/term-page/term-component/translation-card/translation-card.tsx
@@ -69,6 +69,7 @@ const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
                     <input
                       placeholder="Forslag"
                       className="form-control"
+                      autoCapitalize="none"
                       {...register('term', { required: true })}
                     />
                   </Label>

--- a/src/types/nav-item.ts
+++ b/src/types/nav-item.ts
@@ -1,0 +1,5 @@
+export interface NavItem {
+  address: string;
+  icon: string;
+  text: string;
+}


### PR DESCRIPTION
- Utvider søkefelt til å vise treff på termer på engelsk, bokmål og nynorsk. Viser alle tre språk blant søkeresultatene
- Oppdaterer Simens arbeidssted
- Legger til `autoCapitalize="none"` ved nye oversettelsesforslag inne på termsiden
- Hvit tekst på oversettelseskortet (ble nødvendig etter oppdatering av npm-pakker)
- Flytter navigasjonen i hovedmenyen til egen fil