### PR TITLE
Slår opp bokmål- og nynorsktermer i Ordbøkene-API

### DIFF
--- a/src/components/common/search-bar/search-bar.tsx
+++ b/src/components/common/search-bar/search-bar.tsx
@@ -22,14 +22,10 @@ const SearchBar = (): JSX.Element => {
   const selectRef = useRef<SelectInstance<Term> | null>(null);
   const [input, setInput] = useState('');
 
-  const {
-    isLoading: dictionaryLoading,
-    isError: dictionaryError,
-    data: dictionary,
-  } = useDictionary();
+  const dictionaryQuery = useDictionary();
   const navigate = useNavigate();
 
-  const options = !dictionaryLoading && !dictionaryError ? dictionary : [];
+  const options = !dictionaryQuery.isLoading && !dictionaryQuery.isError ? dictionaryQuery.data : [];
 
   const filterOptions = (input: string) =>
     options
@@ -54,8 +50,8 @@ const SearchBar = (): JSX.Element => {
   };
 
   const noOptionsMessage = () => {
-    if (dictionaryLoading) return <p>Laster termliste</p>;
-    if (dictionaryError) return <p>Kunne ikke laste termliste</p>;
+    if (dictionaryQuery.isLoading) return <p>Laster termliste</p>;
+    if (dictionaryQuery.isError) return <p>Kunne ikke laste termliste</p>;
     if (input === '') return null;
     return (
       <Button

--- a/src/components/dictionary-page/dictionary-page.tsx
+++ b/src/components/dictionary-page/dictionary-page.tsx
@@ -28,19 +28,11 @@ const DictionaryPage = (): JSX.Element => {
     AllSubjects
   );
 
-  const {
-    isLoading: dictionaryLoading,
-    isError: dictionaryError,
-    data: dictionary,
-  } = useDictionary();
-  const {
-    isLoading: subjectLoading,
-    isError: subjectError,
-    data: subjects,
-  } = useQuery({ queryKey: ['fields'], queryFn: fetchFields });
+  const dictionaryQuery = useDictionary();
+  const subjectQuery = useQuery({ queryKey: ['fields'], queryFn: fetchFields });
 
-  if (dictionaryLoading) return <Loader />;
-  if (dictionaryError)
+  if (dictionaryQuery.isLoading) return <Loader />;
+  if (dictionaryQuery.isError)
     return (
       <InfoMessage>
         <p>Kunne ikke laste termliste.</p>
@@ -65,14 +57,14 @@ const DictionaryPage = (): JSX.Element => {
   };
 
   const subjectFilterComponent = (): JSX.Element => {
-    if (subjectLoading || subjects === undefined) return <Spinner />;
-    if (subjectError) return <p>Kunne ikke laste fagfelt.</p>;
+    if (subjectQuery.isLoading) return <Spinner />;
+    if (subjectQuery.isError) return <p>Kunne ikke laste fagfelt.</p>;
     return (
       <Select
         className={styles.subjects}
         value={subjectFilter}
         placeholder="Filtrer fagfelt"
-        options={[{ field: 'Alle', subfields: [] }, ...subjects]}
+        options={[{ field: 'Alle', subfields: [] }, ...subjectQuery.data]}
         onChange={(choice) => {
           setSubjectFilter(choice);
         }}
@@ -122,7 +114,7 @@ const DictionaryPage = (): JSX.Element => {
           {subjectFilterComponent()}
         </div>
         <Dictionary
-          dictionary={applyTransFilter(applySubjectFilter(dictionary))}
+          dictionary={applyTransFilter(applySubjectFilter(dictionaryQuery.data))}
         ></Dictionary>
       </div>
     </main>

--- a/src/components/new-term-page/new-term-page.module.css
+++ b/src/components/new-term-page/new-term-page.module.css
@@ -16,3 +16,7 @@
 .buttons > * {
   margin-right: 10px;
 }
+
+:global(.valid-feedback) {
+  filter: brightness(130%);
+}

--- a/src/components/term-page/term-page.tsx
+++ b/src/components/term-page/term-page.tsx
@@ -15,7 +15,7 @@ import Modal from '../common/modal/modal';
 const TermPage = (): JSX.Element => {
   const { termId } = useParams();
 
-  const { isLoading, isError, data: dictionary } = useDictionary();
+  const dictionaryQuery = useDictionary();
   const queryClient = useQueryClient();
   const [isModalOpen, toggleModal] = useToggle(false);
   const [votedTerm, setVotedTerm] = useState<string>('');
@@ -29,15 +29,15 @@ const TermPage = (): JSX.Element => {
     },
   });
 
-  if (isLoading) return <Spinner />;
-  if (isError)
+  if (dictionaryQuery.isLoading) return <Spinner />;
+  if (dictionaryQuery.isError)
     return (
       <InfoMessage>
         <p>Kunne ikke laste termside.</p>
       </InfoMessage>
     );
 
-  const term: Term | undefined = dictionary.find(
+  const term: Term | undefined = dictionaryQuery.data.find(
     (term: Term) => term._id === termId
   );
 

--- a/src/lib/fetch-ordbokene.ts
+++ b/src/lib/fetch-ordbokene.ts
@@ -1,0 +1,12 @@
+import { OrdbokeneResponse } from "../types/ordbokene";
+
+const ordbokeneApiUrl = 'https://ord.uib.no/api/';
+
+export const fetchSuggestions = async (term: string, dialect: 'bm' | 'nn'): Promise<OrdbokeneResponse> => {
+    const res = await fetch(ordbokeneApiUrl + 'suggest?q=' + term + '&dict=' + dialect + '&include=ei&dform=int');
+
+    if (!res.ok) {
+        throw Error(res.status.toString() + ' ' + res.statusText);
+    }
+    return await res.json();
+}

--- a/src/types/ordbokene.ts
+++ b/src/types/ordbokene.ts
@@ -1,0 +1,16 @@
+export interface OrdbokeneResponse {
+    q: string;
+    cnt: number;
+    cmatch: number;
+    a: OrdbokeneLookup
+}
+
+export interface OrdbokeneLookup {
+    inflect?: string[][];
+    exact?: string[][];
+}
+
+export interface Lookup {
+    exact: boolean,
+    inflect: string[],
+}


### PR DESCRIPTION
Slår opp termer på bokmål og nynorsk fra _Legg til term_-siden, og gir validering til brukeren om at
- termen finnes i sin eksakte form i Bokmåls-/Nynorskordboka, eller
- termen finnes som ein bøyning (i sin eksakte form) av en term i Bokmåls-/Nynorskordboka