### PR TITLE
Rydder prettier- og eslint-oppsett

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,9 +5,9 @@ module.exports = {
   },
   extends: [
     'plugin:react/recommended',
-    'standard-with-typescript',
-    'prettier',
     'plugin:@tanstack/eslint-plugin-query/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
   ],
   ignorePatterns: ['vite-env.d.ts', 'vite.config.ts', 'api/*'],
   parser: '@typescript-eslint/parser',
@@ -16,9 +16,23 @@ module.exports = {
     sourceType: 'module',
     project: './tsconfig.json',
   },
-  plugins: ['react', '@tanstack/query'],
+  plugins: [
+    'react',
+    'simple-import-sort',
+    '@tanstack/query',
+    '@typescript-eslint',
+  ],
+  root: true,
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'simple-import-sort/exports': 'error',
+    'simple-import-sort/imports': 'error',
     '@typescript-eslint/no-misused-promises': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
   },
+  settings: {
+    react: {
+      version: "detect",
+    }
+  }
 };

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,6 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "tabWidth": 2,
+  "semi": true,
+  "printWidth": 100
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prettier": "prettier --write ./src/**/*.{ts,tsx,css}",
+    "lint": "eslint ./src"
   },
   "dependencies": {
     "@emotion/react": "11.11.1",
@@ -17,7 +19,6 @@
     "@mui/utils": "5.14.5",
     "@popperjs/core": "2.11.8",
     "@tanstack/react-query": "4.32.6",
-    "@tanstack/react-query-devtools": "4.32.6",
     "bootstrap": "5.3.1",
     "bootstrap-social": "5.1.1",
     "lodash": "4.17.21",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@babel/core": "7.22.10",
     "@tanstack/eslint-plugin-query": "4.32.5",
+    "@tanstack/react-query-devtools": "4.32.6",
     "@types/lodash": "4.14.197",
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",
@@ -44,11 +46,8 @@
     "@vitejs/plugin-react-swc": "3.3.2",
     "eslint": "8.47.0",
     "eslint-config-prettier": "9.0.0",
-    "eslint-config-standard-with-typescript": "37.0.0",
-    "eslint-plugin-import": "2.28.0",
-    "eslint-plugin-n": "16.0.1",
-    "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.33.1",
+    "eslint-plugin-simple-import-sort": "10.0.0",
     "prettier": "3.0.1",
     "typescript": "5.1.6",
     "vite": "4.4.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ dependencies:
   '@tanstack/react-query':
     specifier: 4.32.6
     version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
-  '@tanstack/react-query-devtools':
-    specifier: 4.32.6
-    version: 4.32.6(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0)
   bootstrap:
     specifier: 5.3.1
     version: 5.3.1(@popperjs/core@2.11.8)
@@ -73,6 +70,9 @@ devDependencies:
   '@tanstack/eslint-plugin-query':
     specifier: 4.32.5
     version: 4.32.5
+  '@tanstack/react-query-devtools':
+    specifier: 4.32.6
+    version: 4.32.6(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0)
   '@types/lodash':
     specifier: 4.14.197
     version: 4.14.197
@@ -106,21 +106,12 @@ devDependencies:
   eslint-config-prettier:
     specifier: 9.0.0
     version: 9.0.0(eslint@8.47.0)
-  eslint-config-standard-with-typescript:
-    specifier: 37.0.0
-    version: 37.0.0(@typescript-eslint/eslint-plugin@6.4.0)(eslint-plugin-import@2.28.0)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
-  eslint-plugin-import:
-    specifier: 2.28.0
-    version: 2.28.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)
-  eslint-plugin-n:
-    specifier: 16.0.1
-    version: 16.0.1(eslint@8.47.0)
-  eslint-plugin-promise:
-    specifier: 6.1.1
-    version: 6.1.1(eslint@8.47.0)
   eslint-plugin-react:
     specifier: 7.33.1
     version: 7.33.1(eslint@8.47.0)
+  eslint-plugin-simple-import-sort:
+    specifier: 10.0.0
+    version: 10.0.0(eslint@8.47.0)
   prettier:
     specifier: 3.0.1
     version: 3.0.1
@@ -1082,11 +1073,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       remove-accents: 0.4.2
-    dev: false
+    dev: true
 
   /@tanstack/query-core@4.32.6:
     resolution: {integrity: sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA==}
-    dev: false
 
   /@tanstack/react-query-devtools@4.32.6(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Gd9pBkm2sbeze9P5Yp8R7y0rZVUdoIOhduomDjz138WdJuVbRS4Y8p6gX2uMJFsUFVe7jA6fX/D6NfQ9o5OS/A==}
@@ -1101,7 +1091,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       superjson: 1.13.1
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
+    dev: true
 
   /@tanstack/react-query@4.32.6(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-AITu/IKJJJXsHHeXNBy5bclu12t08usMCY0vFC2dh9SP/w6JAk5U9GwfjOIPj3p+ATADZvxQPe8UiCtMLNeQbg==}
@@ -1119,14 +1109,9 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
-    dev: true
-
-  /@types/json5@0.0.29:
-    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
   /@types/lodash@4.14.197:
@@ -1217,26 +1202,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4
-      eslint: 8.47.0
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@6.4.0(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1256,14 +1221,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@5.62.0:
-    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
   /@typescript-eslint/scope-manager@6.4.0:
@@ -1294,35 +1251,9 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.62.0:
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /@typescript-eslint/types@6.4.0:
     resolution: {integrity: sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@6.4.0(typescript@5.1.6):
@@ -1363,14 +1294,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/visitor-keys@5.62.0:
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@typescript-eslint/visitor-keys@6.4.0:
@@ -1458,17 +1381,6 @@ packages:
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /array.prototype.findlastindex@1.2.2:
-    resolution: {integrity: sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      es-shim-unscopables: 1.0.0
-      get-intrinsic: 1.2.1
     dev: true
 
   /array.prototype.flat@1.3.1:
@@ -1576,12 +1488,6 @@ packages:
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
 
-  /builtins@5.0.1:
-    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
-    dependencies:
-      semver: 7.5.4
-    dev: true
-
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1653,7 +1559,7 @@ packages:
     engines: {node: '>=12.13'}
     dependencies:
       is-what: 4.1.15
-    dev: false
+    dev: true
 
   /cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -1677,17 +1583,6 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1904,155 +1799,6 @@ packages:
       eslint: 8.47.0
     dev: true
 
-  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@6.4.0)(eslint-plugin-import@2.28.0)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.52.0
-      eslint: ^8.0.1
-      eslint-plugin-import: ^2.25.2
-      eslint-plugin-n: '^15.0.0 || ^16.0.0 '
-      eslint-plugin-promise: ^6.0.0
-      typescript: '*'
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
-      eslint: 8.47.0
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.28.0)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)
-      eslint-plugin-import: 2.28.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)
-      eslint-plugin-n: 16.0.1(eslint@8.47.0)
-      eslint-plugin-promise: 6.1.1(eslint@8.47.0)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-config-standard@17.1.0(eslint-plugin-import@2.28.0)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0):
-    resolution: {integrity: sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: ^8.0.1
-      eslint-plugin-import: ^2.25.2
-      eslint-plugin-n: '^15.0.0 || ^16.0.0 '
-      eslint-plugin-promise: ^6.0.0
-    dependencies:
-      eslint: 8.47.0
-      eslint-plugin-import: 2.28.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)
-      eslint-plugin-n: 16.0.1(eslint@8.47.0)
-      eslint-plugin-promise: 6.1.1(eslint@8.47.0)
-    dev: true
-
-  /eslint-import-resolver-node@0.3.9:
-    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
-    dependencies:
-      debug: 3.2.7
-      is-core-module: 2.13.0
-      resolve: 1.22.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.4.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
-      debug: 3.2.7
-      eslint: 8.47.0
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-plugin-es-x@7.2.0(eslint@8.47.0):
-    resolution: {integrity: sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '>=8'
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
-      '@eslint-community/regexpp': 4.6.2
-      eslint: 8.47.0
-    dev: true
-
-  /eslint-plugin-import@2.28.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0):
-    resolution: {integrity: sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
-      array-includes: 3.1.6
-      array.prototype.findlastindex: 1.2.2
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.47.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0)
-      has: 1.0.3
-      is-core-module: 2.13.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.6
-      object.groupby: 1.0.0
-      object.values: 1.1.6
-      resolve: 1.22.4
-      semver: 6.3.1
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-n@16.0.1(eslint@8.47.0):
-    resolution: {integrity: sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
-      builtins: 5.0.1
-      eslint: 8.47.0
-      eslint-plugin-es-x: 7.2.0(eslint@8.47.0)
-      ignore: 5.2.4
-      is-core-module: 2.13.0
-      minimatch: 3.1.2
-      resolve: 1.22.4
-      semver: 7.5.4
-    dev: true
-
-  /eslint-plugin-promise@6.1.1(eslint@8.47.0):
-    resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      eslint: 8.47.0
-    dev: true
-
   /eslint-plugin-react@7.33.1(eslint@8.47.0):
     resolution: {integrity: sha512-L093k0WAMvr6VhNwReB8VgOq5s2LesZmrpPdKz/kZElQDzqS7G7+DnKoqT+w4JwuiGeAhAvHO0fvy0Eyk4ejDA==}
     engines: {node: '>=4'}
@@ -2075,6 +1821,14 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.8
+    dev: true
+
+  /eslint-plugin-simple-import-sort@10.0.0(eslint@8.47.0):
+    resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
+    peerDependencies:
+      eslint: '>=5.0.0'
+    dependencies:
+      eslint: 8.47.0
     dev: true
 
   /eslint-scope@7.2.2:
@@ -2583,7 +2337,7 @@ packages:
   /is-what@4.1.15:
     resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
     engines: {node: '>=12.13'}
-    dev: false
+    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2619,13 +2373,6 @@ packages:
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-    dev: true
-
-  /json5@1.0.2:
-    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
     dev: true
 
   /json5@2.2.3:
@@ -2713,16 +2460,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
-
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
-
-  /ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
   /nanoid@3.3.6:
@@ -2777,15 +2516,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.22.1
-    dev: true
-
-  /object.groupby@1.0.0:
-    resolution: {integrity: sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      get-intrinsic: 1.2.1
     dev: true
 
   /object.hasown@1.1.2:
@@ -2933,7 +2663,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: false
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -3044,7 +2773,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /reactstrap@9.2.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-WWLTEG00qYav0E55PorWHReYTkz5IqkVmQNy0h6U81yqjSp9fOLFGV5pYSVeAUz+yRhU/RTE0oAWy22zr6sOIw==}
@@ -3077,7 +2805,7 @@ packages:
 
   /remove-accents@0.4.2:
     resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
-    dev: false
+    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3090,6 +2818,7 @@ packages:
       is-core-module: 2.13.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /resolve@2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
@@ -3159,7 +2888,6 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /seedrandom@3.0.5:
     resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
@@ -3261,11 +2989,6 @@ packages:
       ansi-regex: 5.0.1
     dev: true
 
-  /strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-    dev: true
-
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3280,7 +3003,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       copy-anything: 3.0.5
-    dev: false
+    dev: true
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -3320,29 +3043,6 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
-    dev: true
-
-  /tsconfig-paths@3.14.2:
-    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.2
-      minimist: 1.2.8
-      strip-bom: 3.0.0
-    dev: true
-
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: true
-
-  /tsutils@3.21.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
       typescript: 5.1.6
     dev: true
 
@@ -3447,7 +3147,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: false
 
   /vite@4.4.9(@types/node@20.5.0):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}

--- a/src/components/about-page/about-page.tsx
+++ b/src/components/about-page/about-page.tsx
@@ -1,12 +1,6 @@
 import { Email, LinkedIn } from '@mui/icons-material';
-import {
-  Card,
-  CardActions,
-  CardContent,
-  CardMedia,
-  IconButton,
-  Typography,
-} from '@mui/material';
+import { Card, CardActions, CardContent, CardMedia, IconButton, Typography } from '@mui/material';
+
 import { Person } from '../../types/person';
 import style from './about-page.module.css';
 import { team } from './team';
@@ -17,28 +11,26 @@ export const AboutPage = (): JSX.Element => (
       <h1>Om oss</h1>
       <section>
         <p>
-          Idéen om Fagord oppstod mens vi begge studerte nanoteknologi ved NTNU
-          i Trondheim. Etter andreåret på studiet foregikk nærmest all
-          undervisning på engelsk, og det ble stadig vanskeligere å ha faglige
-          samtaler på norsk fordi vi rett og slett manglet ordene. Obskure
-          ordbøker, premierte professorer og flittig fantasti kunne noen ganger
-          gi oss nye ord, men disse var det vanskelig å systematisere og dele.
+          Idéen om Fagord oppstod mens vi begge studerte nanoteknologi ved NTNU i Trondheim. Etter
+          andreåret på studiet foregikk nærmest all undervisning på engelsk, og det ble stadig
+          vanskeligere å ha faglige samtaler på norsk fordi vi rett og slett manglet ordene. Obskure
+          ordbøker, premierte professorer og flittig fantasti kunne noen ganger gi oss nye ord, men
+          disse var det vanskelig å systematisere og dele.
         </p>
       </section>
       <section>
         <p>
-          Med Fagord ønsker vi å gjøre det enkelt å finne fagtermer på bokmål og
-          nynorsk, lage et sted hvor en kan etterspørre nye oversettelser
-          (gjennom å legge inn kun den engelske termen) og å få utløp for sine
-          egne oversetterevner – gode som dårlige! I Fagord kan du fritt legge
-          inn egne oversettelser, og det beste man kan gjøre dersom man er uenig
-          er å legge inn bedre ord selv.
+          Med Fagord ønsker vi å gjøre det enkelt å finne fagtermer på bokmål og nynorsk, lage et
+          sted hvor en kan etterspørre nye oversettelser (gjennom å legge inn kun den engelske
+          termen) og å få utløp for sine egne oversetterevner – gode som dårlige! I Fagord kan du
+          fritt legge inn egne oversettelser, og det beste man kan gjøre dersom man er uenig er å
+          legge inn bedre ord selv.
         </p>
       </section>
       <section>
         <p>
-          Fagord er altså ikke en ordbok med noe fasitsvar, men stedet du kan
-          finne, skape og samarbeide om norsk fagspråk. Vel bekomme!
+          Fagord er altså ikke en ordbok med noe fasitsvar, men stedet du kan finne, skape og
+          samarbeide om norsk fagspråk. Vel bekomme!
         </p>
       </section>
     </article>

--- a/src/components/article-page/article-page.tsx
+++ b/src/components/article-page/article-page.tsx
@@ -1,7 +1,8 @@
 import { Outlet, useParams } from 'react-router-dom';
+
 import { ArticleGrid } from '../common/article-grid/article-grid';
-import InfoMessage from '../common/info-message/info-message';
-import Spinner from '../common/spinner/spinner';
+import { InfoMessage } from '../common/info-message/info-message';
+import { Spinner } from '../common/spinner/spinner';
 import { useArticles } from '../utils/use-articles';
 
 export const ArticlePage = (): JSX.Element => {

--- a/src/components/article-page/article/article-content/article-content.tsx
+++ b/src/components/article-page/article/article-content/article-content.tsx
@@ -1,15 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchArticleHtml } from '../../../../lib/fetch';
-import Spinner from '../../../common/spinner/spinner';
 import sanitizeHtml from 'sanitize-html';
-import style from './article-content.module.css';
-import InfoMessage from '../../../common/info-message/info-message';
 
-export const ArticleContent = ({
-  articleId,
-}: {
-  articleId: string;
-}): JSX.Element => {
+import { fetchArticleHtml } from '../../../../lib/fetch';
+import { InfoMessage } from '../../../common/info-message/info-message';
+import { Spinner } from '../../../common/spinner/spinner';
+import style from './article-content.module.css';
+
+export const ArticleContent = ({ articleId }: { articleId: string }): JSX.Element => {
   const {
     isLoading: isLoadingHtml,
     isError: isHtmlError,
@@ -40,10 +37,7 @@ export const ArticleContent = ({
   return (
     <div className="container-sm m-5">
       <div className="col-12 col-lg-8 mx-auto">
-        <div
-          className={style.article}
-          dangerouslySetInnerHTML={{ __html: cleanHtml }}
-        />
+        <div className={style.article} dangerouslySetInnerHTML={{ __html: cleanHtml }} />
       </div>
     </div>
   );

--- a/src/components/article-page/article/article.tsx
+++ b/src/components/article-page/article/article.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
-import InfoMessage from '../../common/info-message/info-message';
+
+import { InfoMessage } from '../../common/info-message/info-message';
 import { useArticles } from '../../utils/use-articles';
 import { ArticleContent } from './article-content/article-content';
 

--- a/src/components/common/article-grid/article-grid.tsx
+++ b/src/components/common/article-grid/article-grid.tsx
@@ -1,20 +1,12 @@
-import {
-  Card,
-  CardActionArea,
-  CardContent,
-  CardMedia,
-  Typography,
-} from '@mui/material';
+import { Card, CardActionArea, CardContent, CardMedia, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
+
+import { Article } from '../../../types/article';
 import { useArticles } from '../../utils/use-articles';
-import Spinner from '../spinner/spinner';
+import { Spinner } from '../spinner/spinner';
 import style from './article-grid.module.css';
 
-export const ArticleGrid = ({
-  hiddenKey,
-}: {
-  hiddenKey?: string;
-}): JSX.Element => {
+export const ArticleGrid = ({ hiddenKey }: { hiddenKey?: string }): JSX.Element => {
   const { isLoading, isError, data: articles } = useArticles();
 
   if (isLoading) return <Spinner />;
@@ -23,8 +15,8 @@ export const ArticleGrid = ({
   return (
     <div className={style.grid}>
       {articles
-        .filter((article: any) => article.documentKey !== hiddenKey)
-        .map((article: any) => (
+        .filter((article: Article) => article.documentKey !== hiddenKey)
+        .map((article: Article) => (
           <Card
             className={style.article}
             key={article.documentKey}
@@ -42,12 +34,7 @@ export const ArticleGrid = ({
                 referrerPolicy="no-referrer"
               />
               <CardContent>
-                <Typography
-                  gutterBottom
-                  variant="h5"
-                  component="div"
-                  color="white"
-                >
+                <Typography gutterBottom variant="h5" component="div" color="white">
                   {article.title}
                 </Typography>
                 <Typography variant="body2" color="white">

--- a/src/components/common/footer/footer.tsx
+++ b/src/components/common/footer/footer.tsx
@@ -1,9 +1,9 @@
-import styles from './footer.module.css';
+import style from './footer.module.css';
 
 const fagordGitHubUrl = 'https://github.com/isakbjugn/fagord';
 
-const Footer = (): JSX.Element => (
-  <footer className={'container-fluid ' + styles.footer}>
+export const Footer = (): JSX.Element => (
+  <footer className={'container-fluid ' + style.footer}>
     <div className="row justify-content-center">
       <div className="col-auto">
         <a href={fagordGitHubUrl}>
@@ -13,5 +13,3 @@ const Footer = (): JSX.Element => (
     </div>
   </footer>
 );
-
-export default Footer;

--- a/src/components/common/header/header.tsx
+++ b/src/components/common/header/header.tsx
@@ -1,29 +1,23 @@
 import { NavLink } from 'react-router-dom';
-import {
-  Navbar,
-  NavbarBrand,
-  Nav,
-  NavItem,
-  Collapse,
-  NavbarToggler,
-} from 'reactstrap';
-import SearchBar from '../search-bar/search-bar';
-import useToggle from '../../utils/use-toggle';
-import styles from './header.module.css';
+import { Collapse, Nav, Navbar, NavbarBrand, NavbarToggler, NavItem } from 'reactstrap';
+
+import { useToggle } from '../../utils/use-toggle';
+import { SearchBar } from '../search-bar/search-bar';
+import style from './header.module.css';
 import { NavLinks } from './nav-links';
 
-const Header = (): JSX.Element => {
+export const Header = (): JSX.Element => {
   const [isNavOpen, toggleNav, setIsNavOpen] = useToggle(false);
   const [isSearchOpen, toggleSearch] = useToggle(false);
 
   return (
     <>
-      <Navbar dark expand="lg" className={styles.navbar}>
+      <Navbar dark expand="lg" className={style.navbar}>
         <NavbarToggler onClick={toggleNav} />
         <NavbarBrand className="mr-auto" href="/hjem">
           <img src="/fagord-logo240.png" height="70" width="150" alt="Fagord" />
         </NavbarBrand>
-        <NavbarToggler onClick={toggleSearch} className={styles.search}>
+        <NavbarToggler onClick={toggleSearch} className={style.search}>
           <span className="fa fa-search" />
         </NavbarToggler>
         <Collapse isOpen={isNavOpen} navbar>
@@ -36,10 +30,7 @@ const Header = (): JSX.Element => {
             {NavLinks.map((navItem) => (
               <NavItem key={navItem.address}>
                 <NavLink className="nav-link text-nowrap" to={navItem.address}>
-                  <span
-                    className={'fa fa-lg ' + navItem.icon + ' ' + styles.icon}
-                  />{' '}
-                  {navItem.text}
+                  <span className={'fa fa-lg ' + navItem.icon + ' ' + style.icon} /> {navItem.text}
                 </NavLink>
               </NavItem>
             ))}
@@ -56,5 +47,3 @@ const Header = (): JSX.Element => {
     </>
   );
 };
-
-export default Header;

--- a/src/components/common/info-message/info-message.tsx
+++ b/src/components/common/info-message/info-message.tsx
@@ -2,7 +2,7 @@ interface InfoMessageProps {
   children: React.ReactNode;
 }
 
-const InfoMessage = ({ children }: InfoMessageProps): JSX.Element => (
+export const InfoMessage = ({ children }: InfoMessageProps): JSX.Element => (
   <div className="container m-auto">
     <div className="col justify-content-center text-center mx-auto">
       <span className="fa fa-info-circle fa-2x" />
@@ -10,5 +10,3 @@ const InfoMessage = ({ children }: InfoMessageProps): JSX.Element => (
     </div>
   </div>
 );
-
-export default InfoMessage;

--- a/src/components/common/jumbotron/jumbotron.tsx
+++ b/src/components/common/jumbotron/jumbotron.tsx
@@ -1,14 +1,11 @@
 import type { ReactNode } from 'react';
-import styles from './jumbotron.module.css';
+
+import style from './jumbotron.module.css';
 
 interface JumbotronProps {
   children: ReactNode;
 }
 
-const Jumbotron = ({ children }: JumbotronProps): JSX.Element => (
-  <section className={'p-4 p-sm-5 rounded-lg m-3 m-sm-5 ' + styles.jumbotron}>
-    {children}
-  </section>
+export const Jumbotron = ({ children }: JumbotronProps): JSX.Element => (
+  <section className={'p-4 p-sm-5 rounded-lg m-3 m-sm-5 ' + style.jumbotron}>{children}</section>
 );
-
-export default Jumbotron;

--- a/src/components/common/loader/loader.tsx
+++ b/src/components/common/loader/loader.tsx
@@ -1,11 +1,9 @@
 import './loader.css';
 
-const Loader = (): JSX.Element => (
+export const Loader = (): JSX.Element => (
   <div className="loader book">
     <div className="page"></div>
     <div className="page"></div>
     <div className="page"></div>
   </div>
 );
-
-export default Loader;

--- a/src/components/common/modal/modal.tsx
+++ b/src/components/common/modal/modal.tsx
@@ -1,10 +1,5 @@
 import type { ReactElement } from 'react';
-import {
-  Button,
-  Modal as ReactstrapModal,
-  ModalBody,
-  ModalFooter,
-} from 'reactstrap';
+import { Button, Modal as ReactstrapModal, ModalBody, ModalFooter } from 'reactstrap';
 
 interface ModalProps {
   isOpen: boolean;
@@ -12,7 +7,7 @@ interface ModalProps {
   children: ReactElement;
 }
 
-const Modal = ({ isOpen, toggle, children }: ModalProps): JSX.Element => (
+export const Modal = ({ isOpen, toggle, children }: ModalProps): JSX.Element => (
   <ReactstrapModal fade={false} isOpen={isOpen}>
     <ModalBody>{children}</ModalBody>
     <ModalFooter>
@@ -22,5 +17,3 @@ const Modal = ({ isOpen, toggle, children }: ModalProps): JSX.Element => (
     </ModalFooter>
   </ReactstrapModal>
 );
-
-export default Modal;

--- a/src/components/common/search-bar/example_terms.ts
+++ b/src/components/common/search-bar/example_terms.ts
@@ -1,49 +1,48 @@
-import { Term } from "../../../types/term";
+import { Term } from '../../../types/term';
 
 const terms: Term[] = [
-    {
-      _id: 'cortex_sub',
-      en: 'cortex',
-      nb: 'hjernebark',
-      nn: 'hjernebork',
-      variants: [
-        { term: 'hjernebark', dialect: 'nb', votes: 1 },
-        { term: 'hjernebork', dialect: 'nn', votes: 1 },
-      ],
-      field: 'Biologi',
-      subfield: 'Nevrovitenskap',
-      pos: 'substantiv',
-      definition:
-        'Ytre, grå substans av nerveceller som dekker overflata på hjernen',
-    },
-    {
-      _id: 'archaea_sub',
-      en: 'archaea',
-      nb: 'arkebakterier',
-      nn: 'arkebakteriar',
-      variants: [
-        { term: 'arkebakterier', dialect: 'nb', votes: 1 },
-        { term: 'arkebakteriar', dialect: 'nn', votes: 1 },
-      ],
-      field: 'Biologi',
-      subfield: 'Mikrobiologi',
-      pos: 'substantiv',
-      definition:
-        'Mikroskopiske, encellede, prokaryote organismer som utseendemessig likner bakterier, men har andre biokjemiske komponenter i cellevegg og ulik form og størrelse på ribosomene.',
-    },
-    {
-      _id: 'benchmark_sub',
-      en: 'benchmark',
-      nb: 'ytelsestest',
-      nn: 'ytingstest',
-      variants: [
-        { term: 'ytelsestest', dialect: 'nb', votes: 1 },
-        { term: 'ytingstest', dialect: 'nn', votes: 1 },
-      ],
-      field: 'IT',
-      subfield: 'Programvare',
-      pos: 'substantiv',
-      definition:
-        'Testing for å måle ytelsen til et programvareprodukt. Måling av systemets svartider eller testing av systemets kapasitet under gitte krav til svartider.',
-    },
-  ];
+  {
+    _id: 'cortex_sub',
+    en: 'cortex',
+    nb: 'hjernebark',
+    nn: 'hjernebork',
+    variants: [
+      { term: 'hjernebark', dialect: 'nb', votes: 1 },
+      { term: 'hjernebork', dialect: 'nn', votes: 1 },
+    ],
+    field: 'Biologi',
+    subfield: 'Nevrovitenskap',
+    pos: 'substantiv',
+    definition: 'Ytre, grå substans av nerveceller som dekker overflata på hjernen',
+  },
+  {
+    _id: 'archaea_sub',
+    en: 'archaea',
+    nb: 'arkebakterier',
+    nn: 'arkebakteriar',
+    variants: [
+      { term: 'arkebakterier', dialect: 'nb', votes: 1 },
+      { term: 'arkebakteriar', dialect: 'nn', votes: 1 },
+    ],
+    field: 'Biologi',
+    subfield: 'Mikrobiologi',
+    pos: 'substantiv',
+    definition:
+      'Mikroskopiske, encellede, prokaryote organismer som utseendemessig likner bakterier, men har andre biokjemiske komponenter i cellevegg og ulik form og størrelse på ribosomene.',
+  },
+  {
+    _id: 'benchmark_sub',
+    en: 'benchmark',
+    nb: 'ytelsestest',
+    nn: 'ytingstest',
+    variants: [
+      { term: 'ytelsestest', dialect: 'nb', votes: 1 },
+      { term: 'ytingstest', dialect: 'nn', votes: 1 },
+    ],
+    field: 'IT',
+    subfield: 'Programvare',
+    pos: 'substantiv',
+    definition:
+      'Testing for å måle ytelsen til et programvareprodukt. Måling av systemets svartider eller testing av systemets kapasitet under gitte krav til svartider.',
+  },
+];

--- a/src/components/common/search-bar/search-bar.tsx
+++ b/src/components/common/search-bar/search-bar.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { SelectInstance } from 'react-select';
+import { SelectInstance, SingleValue } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import { Button } from 'reactstrap';
+
 import type { Term } from '../../../types/term';
-import useDictionary from '../../utils/use-dictionary';
+import { useDictionary } from '../../utils/use-dictionary';
 import style from './search-bar.module.css';
 
 const formatOptionLabel = (term: Term) => (
@@ -18,14 +19,15 @@ const formatOptionLabel = (term: Term) => (
   </div>
 );
 
-const SearchBar = (): JSX.Element => {
+export const SearchBar = (): JSX.Element => {
   const selectRef = useRef<SelectInstance<Term> | null>(null);
   const [input, setInput] = useState('');
 
   const dictionaryQuery = useDictionary();
   const navigate = useNavigate();
 
-  const options = !dictionaryQuery.isLoading && !dictionaryQuery.isError ? dictionaryQuery.data : [];
+  const options =
+    !dictionaryQuery.isLoading && !dictionaryQuery.isError ? dictionaryQuery.data : [];
 
   const filterOptions = (input: string) =>
     options
@@ -33,7 +35,7 @@ const SearchBar = (): JSX.Element => {
         (term) =>
           term.en.toLowerCase().includes(input) ||
           term.nb.toLowerCase().includes(input) ||
-          term.nn.toLowerCase().includes(input)
+          term.nn.toLowerCase().includes(input),
       )
       .slice(0, 5);
 
@@ -43,9 +45,11 @@ const SearchBar = (): JSX.Element => {
     }, 1000);
   };
 
-  const openTermPage = (selected: any): void => {
-    setInput('');
-    navigate('/term/' + (selected._id as string));
+  const openTermPage = (selected?: SingleValue<Term>): void => {
+    if (selected) {
+      setInput('');
+      navigate('/term/' + (selected._id as string));
+    }
   };
 
   const noOptionsMessage = () => {
@@ -100,5 +104,3 @@ const SearchBar = (): JSX.Element => {
     </div>
   );
 };
-
-export default SearchBar;

--- a/src/components/common/spinner/spinner.tsx
+++ b/src/components/common/spinner/spinner.tsx
@@ -1,10 +1,9 @@
 import { Spinner as ReactstrapSpinner } from 'reactstrap';
+
 import style from './spinner.module.css';
 
-const Spinner = (): JSX.Element => (
+export const Spinner = (): JSX.Element => (
   <div className={style.spinner}>
     <ReactstrapSpinner color="light" />
   </div>
 );
-
-export default Spinner;

--- a/src/components/contact-page/contact-page.tsx
+++ b/src/components/contact-page/contact-page.tsx
@@ -1,13 +1,8 @@
+import { AddCircle, GitHub, Mail } from '@mui/icons-material';
+import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  Typography,
-} from '@mui/material';
+
 import style from './contact-page.module.css';
-import { AddCircle, Mail, GitHub } from '@mui/icons-material';
 
 const fagordIssuesUrl = 'https://github.com/isakbjugn/fagord/issues';
 const contactEmailUrl = 'mailto:isakbjugn@gmail.com';
@@ -17,9 +12,8 @@ export const ContactPage = (): JSX.Element => (
   <main className={style.container}>
     <h1>Ta gjerne kontakt!</h1>
     <p>
-      Fagord.no er under kontinuerlig utvikling, og vi tar mer enn gjerne imot
-      tilbakemeldinger og bidrag, både til ordboken og til nettsiden! Her er
-      noen måter du kan bidra:
+      Fagord.no er under kontinuerlig utvikling, og vi tar mer enn gjerne imot tilbakemeldinger og
+      bidrag, både til ordboken og til nettsiden! Her er noen måter du kan bidra:
     </p>
     <section className={style.categories}>
       <Card className={style.card}>
@@ -75,8 +69,8 @@ export const ContactPage = (): JSX.Element => (
             Kom i kontakt med oss
           </Typography>
           <Typography variant="body2" color="white" sx={{ mb: 2 }}>
-            Vi tar også gjerne imot direktehenvendelser, enten om du har andre
-            tanker om Fagord eller bare vil slå av en prat:
+            Vi tar også gjerne imot direktehenvendelser, enten om du har andre tanker om Fagord
+            eller bare vil slå av en prat:
           </Typography>
           <Typography variant="body2" color="white">
             E-post:{' '}
@@ -95,9 +89,9 @@ export const ContactPage = (): JSX.Element => (
     </section>
     <section>
       <p>
-        Til sist: Hvis du er fornøyd med Fagord eller har hatt stor nytte av
-        ordboken, er det også mulig å støtte den videre utviklingen finansielt.
-        Vi har enda ingen etablert måte å gjøre dette, så ta gjerne kontakt på{' '}
+        Til sist: Hvis du er fornøyd med Fagord eller har hatt stor nytte av ordboken, er det også
+        mulig å støtte den videre utviklingen finansielt. Vi har enda ingen etablert måte å gjøre
+        dette, så ta gjerne kontakt på{' '}
         <a className={style.link} href={contactEmailUrl}>
           isakbjugn@gmail.com
         </a>

--- a/src/components/dictionary-page/dictionary-page.tsx
+++ b/src/components/dictionary-page/dictionary-page.tsx
@@ -1,16 +1,17 @@
-import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import Select from 'react-select';
 import { Form, FormGroup, Input, Label } from 'reactstrap';
+
 import { fetchFields } from '../../lib/fetch';
 import type { Subject } from '../../types/subject';
 import type { Term } from '../../types/term';
-import Loader from '../common/loader/loader';
-import styles from './dictionary-page.module.css';
-import Spinner from '../common/spinner/spinner';
-import useDictionary from '../utils/use-dictionary';
+import { InfoMessage } from '../common/info-message/info-message';
+import { Loader } from '../common/loader/loader';
+import { Spinner } from '../common/spinner/spinner';
+import { useDictionary } from '../utils/use-dictionary';
 import { Dictionary } from './dictionary/dictionary';
-import InfoMessage from '../common/info-message/info-message';
+import style from './dictionary-page.module.css';
 
 interface TransFilter {
   text: string;
@@ -22,11 +23,9 @@ type TransFilterType = 'all' | 'translated' | 'incomplete';
 
 const AllSubjects: Subject = { field: 'Alle', subfields: [] };
 
-const DictionaryPage = (): JSX.Element => {
+export const DictionaryPage = (): JSX.Element => {
   const [transFilter, setTransFilter] = useState<TransFilterType>('all');
-  const [subjectFilter, setSubjectFilter] = useState<Subject | null>(
-    AllSubjects
-  );
+  const [subjectFilter, setSubjectFilter] = useState<Subject | null>(AllSubjects);
 
   const dictionaryQuery = useDictionary();
   const subjectQuery = useQuery({ queryKey: ['fields'], queryFn: fetchFields });
@@ -61,7 +60,7 @@ const DictionaryPage = (): JSX.Element => {
     if (subjectQuery.isError) return <p>Kunne ikke laste fagfelt.</p>;
     return (
       <Select
-        className={styles.subjects}
+        className={style.subjects}
         value={subjectFilter}
         placeholder="Filtrer fagfelt"
         options={[{ field: 'Alle', subfields: [] }, ...subjectQuery.data]}
@@ -95,8 +94,8 @@ const DictionaryPage = (): JSX.Element => {
   return (
     <main className="container-sm my-2">
       <div className="col-12 col-lg-10 mx-auto">
-        <div className={styles.header}>
-          <Form className={styles.form}>
+        <div className={style.header}>
+          <Form className={style.form}>
             {transFilters.map((filter) => (
               <FormGroup check inline key={filter.filter}>
                 <Input
@@ -120,5 +119,3 @@ const DictionaryPage = (): JSX.Element => {
     </main>
   );
 };
-
-export default DictionaryPage;

--- a/src/components/dictionary-page/dictionary/dictionary-header/dictionary-header.tsx
+++ b/src/components/dictionary-page/dictionary/dictionary-header/dictionary-header.tsx
@@ -4,9 +4,10 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import { visuallyHidden } from '@mui/utils';
-import { TermTableCell } from '../styled-mui-components';
+
 import type { Language } from '../../../../types/term';
 import type { Order } from '../../../utils/sorting';
+import { TermTableCell } from '../styled-mui-components';
 
 interface HeadCell {
   id: keyof Language;
@@ -33,20 +34,16 @@ const headCells: readonly HeadCell[] = [
 ];
 
 interface DictionaryHeaderProps {
-  onRequestSort: (
-    event: React.MouseEvent<unknown>,
-    property: keyof Language
-  ) => void;
+  onRequestSort: (event: React.MouseEvent<unknown>, property: keyof Language) => void;
   order: Order;
   orderBy: string;
 }
 
 export const DictionaryHeader = (props: DictionaryHeaderProps): JSX.Element => {
   const { order, orderBy, onRequestSort } = props;
-  const createSortHandler =
-    (property: keyof Language) => (event: React.MouseEvent<unknown>) => {
-      onRequestSort(event, property);
-    };
+  const createSortHandler = (property: keyof Language) => (event: React.MouseEvent<unknown>) => {
+    onRequestSort(event, property);
+  };
 
   return (
     <TableHead>

--- a/src/components/dictionary-page/dictionary/dictionary.tsx
+++ b/src/components/dictionary-page/dictionary/dictionary.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -6,12 +5,14 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import type { Term, Language } from '../../../types/term';
-import { TermEntry } from './term-entry/term-entry';
-import { DictionaryHeader } from './dictionary-header/dictionary-header';
+import { useState } from 'react';
+
+import type { Language, Term } from '../../../types/term';
 import type { Order } from '../../utils/sorting';
 import { getComparator } from '../../utils/sorting';
 import style from './dictionary.module.css';
+import { DictionaryHeader } from './dictionary-header/dictionary-header';
+import { TermEntry } from './term-entry/term-entry';
 
 export const Dictionary = (props: { dictionary: Term[] }): JSX.Element => {
   const { dictionary } = props;
@@ -20,10 +21,7 @@ export const Dictionary = (props: { dictionary: Term[] }): JSX.Element => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const handleRequestSort = (
-    event: React.MouseEvent<unknown>,
-    property: keyof Language
-  ): void => {
+  const handleRequestSort = (event: React.MouseEvent<unknown>, property: keyof Language): void => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
@@ -33,26 +31,19 @@ export const Dictionary = (props: { dictionary: Term[] }): JSX.Element => {
     setPage(newPage);
   };
 
-  const handleChangeRowsPerPage = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ): void => {
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>): void => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
   };
 
   // Avoid a layout jump when reaching the last page with empty rows.
-  const emptyRows =
-    page > 0 ? Math.max(0, (1 + page) * rowsPerPage - dictionary.length) : 0;
+  const emptyRows = page > 0 ? Math.max(0, (1 + page) * rowsPerPage - dictionary.length) : 0;
 
   return (
     <Paper sx={{ width: '100%', mb: 2, bgcolor: 'background.paper' }}>
       <TableContainer>
         <Table aria-labelledby="tableTitle" size="small">
-          <DictionaryHeader
-            order={order}
-            orderBy={orderBy}
-            onRequestSort={handleRequestSort}
-          />
+          <DictionaryHeader order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
           <TableBody>
             {dictionary
               .slice()

--- a/src/components/dictionary-page/dictionary/term-entry/term-details.tsx
+++ b/src/components/dictionary-page/dictionary/term-entry/term-details.tsx
@@ -1,9 +1,10 @@
-import { Link } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
+import { Link } from 'react-router-dom';
+
 import type { Term } from '../../../../types/term';
 import style from './term-details.module.css';
 
@@ -43,11 +44,7 @@ export const TermDetails = (props: { term: Term }): JSX.Element => {
         </Table>
       </Box>
       <div className={'col my-2 mx-4 ' + style.button}>
-        <Link
-          className="btn btn-outline-dark btn-sm"
-          to={'/term/' + term._id}
-          role="button"
-        >
+        <Link className="btn btn-outline-dark btn-sm" to={'/term/' + term._id} role="button">
           Til termside
         </Link>
       </div>

--- a/src/components/dictionary-page/dictionary/term-entry/term-entry.tsx
+++ b/src/components/dictionary-page/dictionary/term-entry/term-entry.tsx
@@ -1,21 +1,19 @@
-import { useState } from 'react';
-import Collapse from '@mui/material/Collapse';
-import IconButton from '@mui/material/IconButton';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
 import TableRow from '@mui/material/TableRow';
+import { KeyboardEvent, useState } from 'react';
+
 import type { Term } from '../../../../types/term';
 import { DropdownTableCell, TermTableCell } from '../styled-mui-components';
 import { TermDetails } from './term-details';
 
-export const TermEntry = (props: {
-  term: Term;
-  index: number;
-}): JSX.Element => {
+export const TermEntry = (props: { term: Term; index: number }): JSX.Element => {
   const [open, setOpen] = useState(false);
   const { term, index } = props;
   const labelId = `enhanced-table-checkbox-${index}`;
-  const handleKeyDown = (e: any): void => {
+  const handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Enter') setOpen(!open);
   };
 

--- a/src/components/home-page/home-page.tsx
+++ b/src/components/home-page/home-page.tsx
@@ -1,18 +1,18 @@
 import { Link } from 'react-router-dom';
-import Jumbotron from '../common/jumbotron/jumbotron';
+
 import { ArticleGrid } from '../common/article-grid/article-grid';
+import { Jumbotron } from '../common/jumbotron/jumbotron';
 import style from './home-page.module.css';
 
 const showArticles = process.env.NODE_ENV === 'development';
 
-const Home = (): JSX.Element => (
+export const Home = (): JSX.Element => (
   <main className={style.home}>
     <Jumbotron>
       <h1 className="display-4">Velkommen til Fagord!</h1>
       <p className="lead">
-        Fagord er din kilde til norske fagtermer! Innen fagfelt som IT,
-        nanoteknologi og molekylærbiologi løper utviklingen langt raskere enn
-        norske oversettelser kommer.
+        Fagord er din kilde til norske fagtermer! Innen fagfelt som IT, nanoteknologi og
+        molekylærbiologi løper utviklingen langt raskere enn norske oversettelser kommer.
       </p>
       <p>Her finner du nye termer, og kan foreslå egne!</p>
       <Link className="btn btn-success btn-lg" to="/termliste" role="button">
@@ -22,5 +22,3 @@ const Home = (): JSX.Element => (
     {showArticles && <ArticleGrid />}
   </main>
 );
-
-export default Home;

--- a/src/components/new-term-page/new-term-page.module.css
+++ b/src/components/new-term-page/new-term-page.module.css
@@ -18,8 +18,8 @@
 }
 
 .suggestion-feedback {
-  margin-top: .25rem;
-  font-size: .875em;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
   filter: brightness(85%);
 }
 

--- a/src/components/new-term-page/new-term-page.tsx
+++ b/src/components/new-term-page/new-term-page.tsx
@@ -1,27 +1,34 @@
-import { useForm } from 'react-hook-form';
-import { Button, Form, Label, Row } from 'reactstrap';
-import style from './new-term-page.module.css';
-import { pickBy } from 'lodash';
-import { postTerm } from '../../lib/fetch';
-import { useEffect, useMemo, useState } from 'react';
-import type { Term } from '../../types/term';
-import { Link, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import Modal from '../common/modal/modal';
-import useToggle from '../utils/use-toggle';
-import useDictionary from '../utils/use-dictionary';
-import { createId } from '../utils/create-id';
-import useOrdbokene from '../utils/use-ordbokene';
-import { useDebounce } from '../utils/use-debounce';
+import { pickBy } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useParams } from 'react-router-dom';
+import { Button, Form, Label, Row } from 'reactstrap';
 
-const NewTermPage = (): JSX.Element => {
+import { postTerm } from '../../lib/fetch';
+import type { SubmitTerm, Term } from '../../types/term';
+import { Modal } from '../common/modal/modal';
+import { createId } from '../utils/create-id';
+import { useDebounce } from '../utils/use-debounce';
+import { useDictionary } from '../utils/use-dictionary';
+import { useOrdbokene } from '../utils/use-ordbokene';
+import { useToggle } from '../utils/use-toggle';
+import style from './new-term-page.module.css';
+
+export const NewTermPage = (): JSX.Element => {
   const { term: termFromUrl } = useParams();
   const queryClient = useQueryClient();
   const { register, setValue, watch, reset, handleSubmit } = useForm();
   const debouncedBokmalTerm = useDebounce(watch('nb'), 200);
   const debouncedNynorskTerm = useDebounce(watch('nn'), 200);
-  const [isBokmalTermValid, bokmalValidationText, bokmalSuggestion] = useOrdbokene(debouncedBokmalTerm, 'nb');
-  const [isNynorskTermValid, nynorskValidationText, nynorskSuggestion] = useOrdbokene(debouncedNynorskTerm, 'nn');
+  const [isBokmalTermValid, bokmalValidationText, bokmalSuggestion] = useOrdbokene(
+    debouncedBokmalTerm,
+    'nb',
+  );
+  const [isNynorskTermValid, nynorskValidationText, nynorskSuggestion] = useOrdbokene(
+    debouncedNynorskTerm,
+    'nn',
+  );
   const [result, setResult] = useState<Term | null>();
   const [isErrorModalOpen, toggleErrorModal] = useToggle(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -52,12 +59,12 @@ const NewTermPage = (): JSX.Element => {
 
   useEffect(() => {
     setValue('en', termFromUrl);
-  }, [termFromUrl])
+  }, [termFromUrl]);
 
   const watchField = watch('field', '');
   const watchEn = watch('en', termFromUrl);
   const watchPos = watch('pos', 'substantiv');
-  const onSubmit = (input: any): void => {
+  const onSubmit = (input: SubmitTerm): void => {
     const cleanInput = watchField !== '' ? input : { ...input, subfield: '' };
     mutate(pickBy(cleanInput, (value: string) => value.length > 0));
   };
@@ -66,21 +73,21 @@ const NewTermPage = (): JSX.Element => {
     if (watchEn === '') return false;
     if (dictionaryQuery.isLoading || dictionaryQuery.isError) return false;
     const id = createId(watchEn, watchPos);
-    return dictionaryQuery.data.find((term: any) => term._id === id) !== undefined;
+    return dictionaryQuery.data.find((term: Term) => term._id === id) !== undefined;
   }, [dictionaryQuery, watchEn, watchPos]);
 
   const setFieldFromResult = (result: Term) => {
     setValue('field', result.field);
     setValue('subfield', result.subfield);
-  }
+  };
 
   if (result !== undefined && result !== null)
     return (
       <section className={style.success}>
         <h2>Du har opprettet en term!</h2>
         <p>
-          Takk for ditt bidrag til Fagord. Termen og dens oversettelse er nå
-          lagt til i en voksende termbase.
+          Takk for ditt bidrag til Fagord. Termen og dens oversettelse er nå lagt til i en voksende
+          termbase.
         </p>
         <span className={style.buttons}>
           <Link to={'../term/' + result._id}>
@@ -88,12 +95,18 @@ const NewTermPage = (): JSX.Element => {
               Gå til term
             </Button>
           </Link>
-          <Link to='/ny-term' onClick={() => setResult(null)}>
+          <Link to="/ny-term" onClick={() => setResult(null)}>
             <Button outline color="light">
               Opprett ny term
             </Button>
           </Link>
-          <Link to='/ny-term' onClick={() => {setFieldFromResult(result); setResult(null)}}>
+          <Link
+            to="/ny-term"
+            onClick={() => {
+              setFieldFromResult(result);
+              setResult(null);
+            }}
+          >
             <Button outline color="light">
               Ny term i samme fagfelt
             </Button>
@@ -132,14 +145,14 @@ const NewTermPage = (): JSX.Element => {
                 autoCapitalize="none"
                 {...register('nb')}
               />
-              <div className="valid-feedback">
-                {bokmalValidationText}
-              </div>
+              <div className="valid-feedback">{bokmalValidationText}</div>
               {bokmalSuggestion && (
-                <div className={style["suggestion-feedback"]}>
-                  Mente du <u onClick={() => setValue('nb', bokmalSuggestion)} style={{cursor: 'pointer'}}>
+                <div className={style['suggestion-feedback']}>
+                  Mente du{' '}
+                  <u onClick={() => setValue('nb', bokmalSuggestion)} style={{ cursor: 'pointer' }}>
                     {bokmalSuggestion}
-                    </u>?
+                  </u>
+                  ?
                 </div>
               )}
             </Label>
@@ -153,14 +166,17 @@ const NewTermPage = (): JSX.Element => {
                 autoCapitalize="none"
                 {...register('nn')}
               />
-              <div className="valid-feedback">
-                {nynorskValidationText}
-              </div>
+              <div className="valid-feedback">{nynorskValidationText}</div>
               {nynorskSuggestion && (
-                <div className={style["suggestion-feedback"]}>
-                  Mente du <u onClick={() => setValue('nn', nynorskSuggestion)} style={{cursor: 'pointer'}}>
+                <div className={style['suggestion-feedback']}>
+                  Mente du{' '}
+                  <u
+                    onClick={() => setValue('nn', nynorskSuggestion)}
+                    style={{ cursor: 'pointer' }}
+                  >
                     {nynorskSuggestion}
-                    </u>?
+                  </u>
+                  ?
                 </div>
               )}
             </Label>
@@ -170,22 +186,14 @@ const NewTermPage = (): JSX.Element => {
           <div className="col-sm-6">
             <Label>
               Fagfelt
-              <input
-                className="form-control"
-                type="text"
-                {...register('field')}
-              />
+              <input className="form-control" type="text" {...register('field')} />
             </Label>
           </div>
           {watchField !== null && (
             <div className="col-sm-6">
               <Label>
                 Gren
-                <input
-                  className="form-control"
-                  type="text"
-                  {...register('subfield')}
-                />
+                <input className="form-control" type="text" {...register('subfield')} />
               </Label>
             </div>
           )}
@@ -212,11 +220,7 @@ const NewTermPage = (): JSX.Element => {
         <Row>
           <Label>
             Referanse
-            <input
-              className="form-control"
-              type="text"
-              {...register('reference')}
-            />
+            <input className="form-control" type="text" {...register('reference')} />
           </Label>
         </Row>
         <Button color="success" type="submit">
@@ -236,5 +240,3 @@ const NewTermPage = (): JSX.Element => {
     </main>
   );
 };
-
-export default NewTermPage;

--- a/src/components/router/router.tsx
+++ b/src/components/router/router.tsx
@@ -1,16 +1,17 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import Home from '../home-page/home-page';
-import Header from '../common/header/header';
-import DictionaryPage from '../dictionary-page/dictionary-page';
-import TermPage from '../term-page/term-page';
-import Footer from '../common/footer/footer';
-import NewTermPage from '../new-term-page/new-term-page';
 import { useQueryClient } from '@tanstack/react-query';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
 import { fetchTerms } from '../../lib/fetch';
-import { ArticlePage } from '../article-page/article-page';
-import { Article } from '../article-page/article/article';
 import { AboutPage } from '../about-page/about-page';
+import { Article } from '../article-page/article/article';
+import { ArticlePage } from '../article-page/article-page';
+import { Footer } from '../common/footer/footer';
+import { Header } from '../common/header/header';
 import { ContactPage } from '../contact-page/contact-page';
+import { DictionaryPage } from '../dictionary-page/dictionary-page';
+import { Home } from '../home-page/home-page';
+import { NewTermPage } from '../new-term-page/new-term-page';
+import { TermPage } from '../term-page/term-page';
 
 export const Router = (): JSX.Element => {
   const queryClient = useQueryClient();

--- a/src/components/term-page/term-component/definition/definition.tsx
+++ b/src/components/term-page/term-component/definition/definition.tsx
@@ -1,17 +1,19 @@
-import { useForm } from 'react-hook-form';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
 import { Button, Form, Label, Row } from 'reactstrap';
+
 import { updateTerm } from '../../../../lib/fetch';
-import useToggle from '../../../utils/use-toggle';
-import Spinner from '../../../common/spinner/spinner';
-import styles from './definition.module.css';
+import { SubmitTerm } from '../../../../types/term';
+import { Spinner } from '../../../common/spinner/spinner';
+import { useToggle } from '../../../utils/use-toggle';
+import style from './definition.module.css';
 
 interface DefinitionProps {
   termId: string;
   definition?: string;
 }
 
-const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
+export const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
   const queryClient = useQueryClient();
   const [isWriting, toggleWriting] = useToggle(false);
   const { register, handleSubmit, setValue } = useForm();
@@ -24,7 +26,7 @@ const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
 
   if (isLoading) return <Spinner />;
 
-  const onSubmit = (input: any): void => {
+  const onSubmit = (input: SubmitTerm): void => {
     toggleWriting();
     mutate({ termId, term: input });
   };
@@ -37,13 +39,7 @@ const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
 
   return (
     <div>
-      <p>
-        {definition !== '' ? (
-          definition
-        ) : (
-          <em>Ingen definisjon tilgjengelig.</em>
-        )}
-      </p>
+      <p>{definition !== '' ? definition : <em>Ingen definisjon tilgjengelig.</em>}</p>
       <Form onSubmit={handleSubmit(onSubmit)}>
         {isWriting && (
           <Row>
@@ -56,7 +52,7 @@ const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
             </Label>
           </Row>
         )}
-        <span className={styles.buttons}>
+        <span className={style.buttons}>
           {isWriting && (
             <Button color="success" type="submit">
               Send inn
@@ -77,5 +73,3 @@ const Definition = ({ termId, definition }: DefinitionProps): JSX.Element => {
     </div>
   );
 };
-
-export default Definition;

--- a/src/components/term-page/term-component/term-component.tsx
+++ b/src/components/term-page/term-component/term-component.tsx
@@ -1,15 +1,16 @@
 import { IosShare } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
+
 import type { Term } from '../../../types/term';
-import Definition from './definition/definition';
-import TranslationCard from './translation-card/translation-card';
+import { Definition } from './definition/definition';
 import style from './term-component.module.css';
+import { TranslationCard } from './translation-card/translation-card';
 
 interface TermComponentProps {
   term: Term;
 }
 
-const TermComponent = ({ term }: TermComponentProps): JSX.Element => {
+export const TermComponent = ({ term }: TermComponentProps): JSX.Element => {
   if (term === null) return <></>;
 
   const fieldSpec = term.subfield !== '' ? term.subfield : term.field;
@@ -55,5 +56,3 @@ const TermComponent = ({ term }: TermComponentProps): JSX.Element => {
     </article>
   );
 };
-
-export default TermComponent;

--- a/src/components/term-page/term-component/translation-card/translation-card.tsx
+++ b/src/components/term-page/term-component/translation-card/translation-card.tsx
@@ -1,27 +1,18 @@
-import type { Term } from '../../../../types/term';
-import {
-  Button,
-  Card,
-  CardBody,
-  CardText,
-  CardTitle,
-  Col,
-  Form,
-  Label,
-  Row,
-} from 'reactstrap';
-import styles from './translation-card.module.css';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useToggle from '../../../utils/use-toggle';
 import { useForm } from 'react-hook-form';
+import { Button, Card, CardBody, CardText, CardTitle, Col, Form, Label, Row } from 'reactstrap';
+
 import { addVariant } from '../../../../lib/fetch';
-import Spinner from '../../../common/spinner/spinner';
+import type { SubmitVariant, Term } from '../../../../types/term';
+import { Spinner } from '../../../common/spinner/spinner';
+import { useToggle } from '../../../utils/use-toggle';
+import styles from './translation-card.module.css';
 
 interface TranslationCardProps {
   term: Term;
 }
 
-const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
+export const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
   const queryClient = useQueryClient();
   const [isWriting, toggleWriting] = useToggle(false);
   const { register, handleSubmit } = useForm();
@@ -34,7 +25,7 @@ const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
 
   if (term === null) return <></>;
 
-  const onSubmit = (input: any): void => {
+  const onSubmit = (input: SubmitVariant): void => {
     toggleWriting();
     mutate({ termId: term._id, variant: input });
   };
@@ -89,10 +80,7 @@ const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
                       autoComplete="off"
                       {...register('dialect')}
                     />
-                    <label
-                      className="btn btn-outline-light"
-                      htmlFor="btncheck1"
-                    >
+                    <label className="btn btn-outline-light" htmlFor="btncheck1">
                       nb
                     </label>
 
@@ -104,10 +92,7 @@ const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
                       autoComplete="off"
                       {...register('dialect')}
                     />
-                    <label
-                      className="btn btn-outline-light"
-                      htmlFor="btncheck2"
-                    >
+                    <label className="btn btn-outline-light" htmlFor="btncheck2">
                       nn
                     </label>
                   </div>
@@ -136,5 +121,3 @@ const TranslationCard = ({ term }: TranslationCardProps): JSX.Element => {
     </Card>
   );
 };
-
-export default TranslationCard;

--- a/src/components/term-page/term-page.tsx
+++ b/src/components/term-page/term-page.tsx
@@ -1,18 +1,19 @@
-import { Link, useParams } from 'react-router-dom';
-import type { Term } from '../../types/term';
-import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
-import TermComponent from './term-component/term-component';
-import InfoMessage from '../common/info-message/info-message';
-import VariantCloud from './variant-cloud/variant-cloud';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { voteForVariant } from '../../lib/fetch';
-import useDictionary from '../utils/use-dictionary';
-import Spinner from '../common/spinner/spinner';
-import useToggle from '../utils/use-toggle';
-import Modal from '../common/modal/modal';
+import { Link, useParams } from 'react-router-dom';
+import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 
-const TermPage = (): JSX.Element => {
+import { voteForVariant } from '../../lib/fetch';
+import type { Term } from '../../types/term';
+import { InfoMessage } from '../common/info-message/info-message';
+import { Modal } from '../common/modal/modal';
+import { Spinner } from '../common/spinner/spinner';
+import { useDictionary } from '../utils/use-dictionary';
+import { useToggle } from '../utils/use-toggle';
+import { TermComponent } from './term-component/term-component';
+import { VariantCloud } from './variant-cloud/variant-cloud';
+
+export const TermPage = (): JSX.Element => {
   const { termId } = useParams();
 
   const dictionaryQuery = useDictionary();
@@ -37,9 +38,7 @@ const TermPage = (): JSX.Element => {
       </InfoMessage>
     );
 
-  const term: Term | undefined = dictionaryQuery.data.find(
-    (term: Term) => term._id === termId
-  );
+  const term: Term | undefined = dictionaryQuery.data.find((term: Term) => term._id === termId);
 
   if (term === undefined)
     return (
@@ -60,11 +59,7 @@ const TermPage = (): JSX.Element => {
           </Breadcrumb>
         </div>
         <TermComponent term={term} />
-        <VariantCloud
-          termId={term._id}
-          variants={term.variants}
-          mutate={mutate}
-        />
+        <VariantCloud termId={term._id} variants={term.variants} mutate={mutate} />
         <Modal isOpen={isModalOpen} toggle={toggleModal}>
           <p>
             Du har gitt én stemme til <em>«{votedTerm}»</em>.
@@ -74,5 +69,3 @@ const TermPage = (): JSX.Element => {
     </main>
   );
 };
-
-export default TermPage;

--- a/src/components/term-page/variant-cloud/variant-cloud.tsx
+++ b/src/components/term-page/variant-cloud/variant-cloud.tsx
@@ -1,20 +1,17 @@
 import type { UseMutateFunction } from '@tanstack/react-query';
 import { TagCloud } from 'react-tagcloud';
+
 import type { VoteForVariantArguments } from '../../../lib/fetch';
-import type { Variant } from '../../../types/term';
-import styles from './variant-cloud.module.css';
+import type { Variant, VariantVote } from '../../../types/term';
+import style from './variant-cloud.module.css';
 
 interface VariantCloudProps {
   termId: string;
   variants: Variant[];
-  mutate: UseMutateFunction<any, unknown, VoteForVariantArguments, unknown>;
+  mutate: UseMutateFunction<Variant, unknown, VoteForVariantArguments, unknown>;
 }
 
-const VariantCloud = ({
-  termId,
-  variants,
-  mutate,
-}: VariantCloudProps): JSX.Element => {
+export const VariantCloud = ({ termId, variants, mutate }: VariantCloudProps): JSX.Element => {
   const options = {
     luminosity: 'light',
     hue: 'red',
@@ -28,7 +25,7 @@ const VariantCloud = ({
 
   return (
     <TagCloud
-      className={styles.cloud}
+      className={style.cloud}
       minSize={20}
       maxSize={40}
       colorOptions={options}
@@ -40,7 +37,7 @@ const VariantCloud = ({
           count: v.votes,
         };
       })}
-      onClick={(tag: any) => {
+      onClick={(tag: VariantVote) => {
         mutate({
           termId,
           variant: {
@@ -52,5 +49,3 @@ const VariantCloud = ({
     />
   );
 };
-
-export default VariantCloud;

--- a/src/components/utils/sorting.ts
+++ b/src/components/utils/sorting.ts
@@ -1,3 +1,5 @@
+import { Term } from '../../types/term';
+
 export type Order = 'asc' | 'desc';
 
 const descendingComparator = <T>(A: T, B: T, orderBy: keyof T): number => {
@@ -10,9 +12,9 @@ const descendingComparator = <T>(A: T, B: T, orderBy: keyof T): number => {
   return 0;
 };
 
-export const getComparator = <Key extends keyof any>(
+export const getComparator = <Key extends keyof Term>(
   order: Order,
-  orderBy: Key
+  orderBy: Key,
 ): ((a: { [key in Key]: string }, b: { [key in Key]: string }) => number) => {
   return order === 'desc'
     ? (a, b) => descendingComparator(a, b, orderBy)

--- a/src/components/utils/use-articles.ts
+++ b/src/components/utils/use-articles.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { fetchArticles } from '../../lib/fetch';
 
 export const useArticles = () =>

--- a/src/components/utils/use-debounce.ts
+++ b/src/components/utils/use-debounce.ts
@@ -1,17 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react';
 
 export const useDebounce = <T>(value: T, milliSeconds: number) => {
- const [debouncedValue, setDebouncedValue] = useState(value);
+  const [debouncedValue, setDebouncedValue] = useState(value);
 
- useEffect(() => {
-   const handler = setTimeout(() => {
-     setDebouncedValue(value);
-   }, milliSeconds);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, milliSeconds);
 
-   return () => {
-     clearTimeout(handler);
-   };
- }, [value, milliSeconds]);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, milliSeconds]);
 
- return debouncedValue;
+  return debouncedValue;
 };

--- a/src/components/utils/use-dictionary.ts
+++ b/src/components/utils/use-dictionary.ts
@@ -1,9 +1,8 @@
-import { fetchTerms } from '../../lib/fetch';
-import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchTerms } from '../../lib/fetch';
 import type { Term } from '../../types/term';
 
-const useDictionary = (): UseQueryResult<Term[]> =>
+export const useDictionary = (): UseQueryResult<Term[]> =>
   useQuery({ queryKey: ['dictionary'], queryFn: fetchTerms });
-
-export default useDictionary;

--- a/src/components/utils/use-ordbokene.ts
+++ b/src/components/utils/use-ordbokene.ts
@@ -1,47 +1,51 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { fetchSuggestions } from '../../lib/fetch-ordbokene';
-import { OrdbokeneResponse, Lookup } from '../../types/ordbokene';
+import { Lookup, OrdbokeneResponse } from '../../types/ordbokene';
 
 const DictionaryName = {
-  nb: "Bokmålsordboka",
-  nn: "Nynorskordboka",
+  nb: 'Bokmålsordboka',
+  nn: 'Nynorskordboka',
 };
 
-const useOrdbokene = (searchTerm: string, dialect: 'nb' | 'nn' ) => {
+export const useOrdbokene = (searchTerm: string, dialect: 'nb' | 'nn') => {
   const { data: lookup } = useQuery({
     queryKey: ['ordbokene', searchTerm, dialect],
     queryFn: () => fetchSuggestions(searchTerm, dialect),
-    select: data => getLookupFromOrdbokene(data, searchTerm),
+    select: (data) => getLookupFromOrdbokene(data, searchTerm),
     enabled: searchTerm !== undefined && searchTerm !== '',
   });
 
   return lookup === undefined || searchTerm === undefined || searchTerm === ''
     ? ['', false]
-    : [isTermValid(lookup), getValidationText(lookup, DictionaryName[dialect]), getSuggestion(lookup)] as const;
+    : ([
+        isTermValid(lookup),
+        getValidationText(lookup, DictionaryName[dialect]),
+        getSuggestion(lookup),
+      ] as const);
 };
 
 const getLookupFromOrdbokene = (lookup: OrdbokeneResponse, searchTerm: string): Lookup => {
-  const exactMatches: string[] = lookup.a.exact ? lookup.a.exact.map(term => term[0]) : [];
+  const exactMatches: string[] = lookup.a.exact ? lookup.a.exact.map((term) => term[0]) : [];
   const exact = exactMatches.includes(searchTerm);
-  const inflect = lookup.a.inflect ? lookup.a.inflect.map(term => term[0]) : [];
-  const similar = lookup.a.similar ? lookup.a.similar.map(term => term[0]) : [];
+  const inflect = lookup.a.inflect ? lookup.a.inflect.map((term) => term[0]) : [];
+  const similar = lookup.a.similar ? lookup.a.similar.map((term) => term[0]) : [];
 
   return { exact, inflect, similar };
 };
 
 const isTermValid = (lookup: Lookup): boolean =>
-  lookup ? (lookup?.exact || lookup?.inflect.length > 0) : false;
+  lookup ? lookup?.exact || lookup?.inflect.length > 0 : false;
 
 const getValidationText = (lookup: Lookup, dictionaryName: string): string => {
   if (lookup.exact) {
     return `Finnes i ${dictionaryName}`;
-  }
-  else if (lookup.inflect) {
+  } else if (lookup.inflect) {
     return `Bøyning av ${lookup.inflect[0]} i ${dictionaryName}`;
   } else {
     return '';
   }
-}
+};
 
 const getSuggestion = (lookup: Lookup): string => {
   if (lookup.similar.length > 0 && !lookup.exact && lookup.inflect.length == 0) {
@@ -49,6 +53,4 @@ const getSuggestion = (lookup: Lookup): string => {
   } else {
     return '';
   }
-}
-
-export default useOrdbokene;
+};

--- a/src/components/utils/use-toggle.ts
+++ b/src/components/utils/use-toggle.ts
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useState } from 'react';
 
-const useToggle = (
-  initialState = false
+export const useToggle = (
+  initialState = false,
 ): readonly [boolean, () => void, Dispatch<SetStateAction<boolean>>] => {
   const [status, setStatus] = useState(initialState);
 
@@ -11,5 +11,3 @@ const useToggle = (
   }, []);
   return [status, toggleStatus, setStatus] as const;
 };
-
-export default useToggle;

--- a/src/fagord-main.tsx
+++ b/src/fagord-main.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { Router } from './components/router/router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-social/bootstrap-social.css';
 import './index.css';
+
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import { Router } from './components/router/router';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -41,5 +43,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       </ThemeProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,14 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--color-light-blue);
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 :root {

--- a/src/lib/fetch-ordbokene.ts
+++ b/src/lib/fetch-ordbokene.ts
@@ -1,18 +1,21 @@
-import { OrdbokeneResponse } from "../types/ordbokene";
+import { OrdbokeneResponse } from '../types/ordbokene';
 
 const ordbokeneApiUrl = 'https://ord.uib.no/api/';
 
 const DictionaryKey = {
-    nb: "bm",
-    nn: "nn",
+  nb: 'bm',
+  nn: 'nn',
 };
 
-export const fetchSuggestions = async (term: string, dialect: 'nb' | 'nn'): Promise<OrdbokeneResponse> => {
-    const queryString = `q=${term}&dict=${DictionaryKey[dialect]}&include=eis&dform=int`
-    const res = await fetch(`${ordbokeneApiUrl}suggest?${queryString}`);
+export const fetchSuggestions = async (
+  term: string,
+  dialect: 'nb' | 'nn',
+): Promise<OrdbokeneResponse> => {
+  const queryString = `q=${term}&dict=${DictionaryKey[dialect]}&include=eis&dform=int`;
+  const res = await fetch(`${ordbokeneApiUrl}suggest?${queryString}`);
 
-    if (!res.ok) {
-        throw Error(res.status.toString() + ' ' + res.statusText);
-    }
-    return await res.json();
-}
+  if (!res.ok) {
+    throw Error(res.status.toString() + ' ' + res.statusText);
+  }
+  return await res.json();
+};

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,8 +1,10 @@
-import type { Subject } from '../types/subject';
-import type { Term, Variant } from '../types/term';
+import { QueryFunctionContext } from '@tanstack/react-query';
 
-const baseApiUri =
-  process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : '';
+import { Article } from '../types/article';
+import type { Subject } from '../types/subject';
+import type { SubmitTerm, SubmitVariant, Term, Variant } from '../types/term';
+
+const baseApiUri = process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : '';
 
 export const articleUrl = baseApiUri + '/api/artikler/';
 
@@ -24,7 +26,7 @@ export const fetchFields = async (): Promise<Subject[]> => {
   return await res.json();
 };
 
-export const fetchArticles = async (): Promise<any[]> => {
+export const fetchArticles = async (): Promise<Article[]> => {
   const res = await fetch(baseApiUri + '/api/artikler');
 
   if (!res.ok) {
@@ -33,7 +35,7 @@ export const fetchArticles = async (): Promise<any[]> => {
   return await res.json();
 };
 
-export const fetchArticleHtml = async ({ queryKey }: any): Promise<string> => {
+export const fetchArticleHtml = async ({ queryKey }: QueryFunctionContext): Promise<string> => {
   const [_, articleId] = queryKey;
   const res = await fetch(baseApiUri + '/api/artikler/' + articleId);
 
@@ -45,7 +47,7 @@ export const fetchArticleHtml = async ({ queryKey }: any): Promise<string> => {
   return innerHtml;
 };
 
-export const postTerm = async (term: any): Promise<Term> => {
+export const postTerm = async (term: SubmitTerm): Promise<Term> => {
   const res = await fetch(baseApiUri + '/api/termer', {
     headers: {
       Accept: 'application/json',
@@ -63,13 +65,10 @@ export const postTerm = async (term: any): Promise<Term> => {
 
 interface UpdateTermArguments {
   termId: string;
-  term: any;
+  term: SubmitTerm;
 }
 
-export const updateTerm = async ({
-  termId,
-  term,
-}: UpdateTermArguments): Promise<Term> => {
+export const updateTerm = async ({ termId, term }: UpdateTermArguments): Promise<Term> => {
   const res = await fetch(baseApiUri + '/api/termer/' + termId, {
     headers: {
       Accept: 'application/json',
@@ -87,13 +86,10 @@ export const updateTerm = async ({
 
 export interface AddVariantArguments {
   termId: string;
-  variant: Variant;
+  variant: SubmitVariant;
 }
 
-export const addVariant = async ({
-  termId,
-  variant,
-}: VoteForVariantArguments): Promise<Variant> => {
+export const addVariant = async ({ termId, variant }: AddVariantArguments): Promise<Variant> => {
   const res = await fetch(baseApiUri + '/api/termer/' + termId + '/varianter', {
     headers: {
       Accept: 'application/json',

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,8 @@
+export interface Article {
+  documentId: string;
+  documentKey: string;
+  documentTitle: string;
+  imageUrl: string;
+  subtitle: string;
+  title: string;
+}

--- a/src/types/ordbokene.ts
+++ b/src/types/ordbokene.ts
@@ -1,18 +1,18 @@
 export interface OrdbokeneResponse {
-    q: string;
-    cnt: number;
-    cmatch: number;
-    a: OrdbokeneLookup
+  q: string;
+  cnt: number;
+  cmatch: number;
+  a: OrdbokeneLookup;
 }
 
 export interface OrdbokeneLookup {
-    inflect?: string[][];
-    exact?: string[][];
-    similar?: string[][];
+  inflect?: string[][];
+  exact?: string[][];
+  similar?: string[][];
 }
 
 export interface Lookup {
-    exact: boolean,
-    inflect: string[],
-    similar: string[],
+  exact: boolean;
+  inflect: string[];
+  similar: string[];
 }

--- a/src/types/term.ts
+++ b/src/types/term.ts
@@ -17,3 +17,12 @@ export interface Variant {
 }
 
 export type Language = Pick<Term, 'en' | 'nb' | 'nn'>;
+
+export type SubmitTerm = Partial<Term>;
+
+export type SubmitVariant = Partial<Variant>;
+
+export type VariantVote = Variant & {
+  count: number;
+  value: string;
+};


### PR DESCRIPTION
- Fastsetter prettier-oppsett (Prettier bør også brukes som VS Code-utvidelse)
- Fjerner bruken av `export default`
- Fjernet eslint-relaterte npm-pakker som ikke ble brukt i eslint-oppsett
- Rydder i eslint-oppsett
- Kjørt prettier på alle filer i ./src
- Jobbet metodisk med å løse alle feil påpekt av eslint