### PR TITLE
Skiller vekselknapp i egen komponent

### DIFF
--- a/src/components/common/toggle-button/toggle-button.tsx
+++ b/src/components/common/toggle-button/toggle-button.tsx
@@ -1,0 +1,42 @@
+import { FieldValues, UseFormRegister } from 'react-hook-form';
+
+interface ToggleButtonProps {
+  leftLabel: string;
+  rightLabel: string;
+  fieldLabel: string;
+  register: UseFormRegister<FieldValues>;
+}
+
+export const ToggleButton = ({
+  leftLabel,
+  rightLabel,
+  fieldLabel,
+  register,
+}: ToggleButtonProps) => (
+  <div className="btn-group" role="group" aria-label="Basic checkbox toggle button group">
+    <input
+      value={leftLabel}
+      defaultChecked={true}
+      type="radio"
+      className="btn-check"
+      id="btncheck1"
+      autoComplete="off"
+      {...register(fieldLabel)}
+    />
+    <label className="btn btn-outline-light" htmlFor="btncheck1">
+      {leftLabel}
+    </label>
+
+    <input
+      value={rightLabel}
+      type="radio"
+      className="btn-check"
+      id="btncheck2"
+      autoComplete="off"
+      {...register(fieldLabel)}
+    />
+    <label className="btn btn-outline-light" htmlFor="btncheck2">
+      {rightLabel}
+    </label>
+  </div>
+);

--- a/src/components/term-page/term-component/term-component.tsx
+++ b/src/components/term-page/term-component/term-component.tsx
@@ -49,7 +49,7 @@ export const TermComponent = ({ term }: TermComponentProps): JSX.Element => {
         <div className="col-12 col-md-6">
           <Definition termId={term._id} definition={term.definition} />
         </div>
-        <div className="col-8 col-sm-8 col-md-6 mt-2">
+        <div className="col-12 col-sm-8 col-md-6 mt-2">
           <TranslationCard term={term} />
         </div>
       </div>

--- a/src/components/term-page/term-component/translation-card/translation-card.module.css
+++ b/src/components/term-page/term-component/translation-card/translation-card.module.css
@@ -8,5 +8,21 @@
 }
 
 .buttons > * {
+  margin-top: 10px;
   margin-right: 10px;
+}
+
+.suggestion-feedback {
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  filter: brightness(85%);
+  white-space: nowrap;
+}
+
+.valid-feedback {
+  white-space: nowrap;
+}
+
+:global(.valid-feedback) {
+  filter: brightness(130%);
 }


### PR DESCRIPTION
- Skiller ut vekselknapp i egen komponent (må bruke `register: UseFormRegister<FieldValues>` fra `react-hook-form`)
- Bruker Ordbøkene.no (`useOrdbokene`) på _Legg til variant_-komponenten