### PR TITLE
Fjerner lodash, lager egen pickBy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@tanstack/react-query": "4.32.6",
     "bootstrap": "5.3.1",
     "bootstrap-social": "5.1.1",
-    "lodash": "4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "7.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ dependencies:
   bootstrap-social:
     specifier: 5.1.1
     version: 5.1.1
-  lodash:
-    specifier: 4.17.21
-    version: 4.17.21
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -2413,10 +2410,6 @@ packages:
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}

--- a/src/pages/new-term-page/new-term-page.tsx
+++ b/src/pages/new-term-page/new-term-page.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { pickBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useParams } from 'react-router-dom';
@@ -9,6 +8,7 @@ import { Modal } from '../../components/modal/modal';
 import { postTerm } from '../../lib/fetch';
 import type { SubmitTerm, Term } from '../../types/term';
 import { createId } from '../../utils/create-id';
+import { removeEmptyString } from '../../utils/pick-by';
 import { useDebounce } from '../../utils/use-debounce';
 import { useDictionary } from '../../utils/use-dictionary';
 import { useOrdbokene } from '../../utils/use-ordbokene';
@@ -67,7 +67,7 @@ export const NewTermPage = (): JSX.Element => {
   const watchPos = watch('pos', 'substantiv');
   const onSubmit = (input: SubmitTerm): void => {
     const cleanInput = watchField !== '' ? input : { ...input, subfield: '' };
-    mutate(pickBy(cleanInput, (value: string) => value.length > 0));
+    mutate(removeEmptyString(cleanInput));
   };
 
   const existsInTermbase = useMemo((): boolean => {

--- a/src/utils/pick-by.ts
+++ b/src/utils/pick-by.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const removeEmptyString = (obj: any) => {
+  const result: any = {};
+
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key) && obj[key] !== '') {
+      result[key] = obj[key];
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION
Fjerner `lodash`-biblioteket, som ofte er relativt stort i den sammenpakkede applikasjonen, og implementerer heller en egen `removeEmptyStrings`-metode (som `pickBy` tidligere ble brukt til).

`index.js` går nå ned fra 827,77 kB til 752,96 kB.