### PR TITLE
Navigasjonsmeny langs rad

### DIFF
--- a/app/styles/header.module.css
+++ b/app/styles/header.module.css
@@ -1,6 +1,6 @@
 @media only screen and (max-width: 991px) {
-  :global(.navbar-nav) {
-    justify-self: center;
+  ul:global(.navbar-nav) {
+    justify-content: center;
     flex-direction: row;
     column-gap: 16px;
     flex-wrap: wrap;


### PR DESCRIPTION
CSS i `header.module.css` var ikke tilstrekkelig til å organisere navigasjonsmeny horisontalt. Øker CSS-spesifisitet og bytter `justify-self` med `justify-content`.