### PR TITLE
Tar i bruk singleFetch fra remix v3

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -11,7 +11,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 
 import { EMOTION_CACHE_KEY } from '~/lib/constants';
 
-const ABORT_DELAY = 5_000;
+export const streamTimeout = 5000;
 
 export default function handleRequest(
   request: Request,
@@ -38,7 +38,7 @@ function handleBotRequest(
 
     const { pipe, abort } = renderToPipeableStream(
       <CacheProvider value={emotionCache}>
-        <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />
+        <RemixServer context={remixContext} url={request.url} />
       </CacheProvider>,
       {
         onAllReady() {
@@ -76,7 +76,7 @@ function handleBotRequest(
       },
     );
 
-    setTimeout(abort, ABORT_DELAY);
+    setTimeout(abort, streamTimeout + 1000);
   });
 }
 
@@ -92,7 +92,7 @@ function handleBrowserRequest(
 
     const { pipe, abort } = renderToPipeableStream(
       <CacheProvider value={emotionCache}>
-        <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />
+        <RemixServer context={remixContext} url={request.url} />
       </CacheProvider>,
       {
         onShellReady() {
@@ -129,6 +129,6 @@ function handleBrowserRequest(
       },
     );
 
-    setTimeout(abort, ABORT_DELAY);
+    setTimeout(abort, streamTimeout + 1000);
   });
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider } from '@mui/material';
 import type { LinksFunction, LoaderFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { defer } from '@remix-run/node';
 import type { ClientLoaderFunctionArgs } from '@remix-run/react';
 import { Links, Meta, Outlet, Scripts, useRouteError } from '@remix-run/react';
 import bootstrapStylesHref from 'bootstrap/dist/css/bootstrap.min.css?url';
@@ -30,11 +29,11 @@ export const loader: LoaderFunction = async ({ request }: LoaderFunctionArgs) =>
   const q = new URL(request.url).searchParams.get('q');
   const searchResult = terms.then((terms) => filterTerms(terms, q));
 
-  return defer({
+  return {
     terms: terms.then((data) => data.sort((a: Term, b: Term) => a.en.localeCompare(b.en))),
     q: q,
     searchResult: searchResult,
-  });
+  };
 };
 
 let isInitialRequest = true;

--- a/app/routes/ny-term.$termId.opprettet.tsx
+++ b/app/routes/ny-term.$termId.opprettet.tsx
@@ -1,12 +1,11 @@
 import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node';
-import { json } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 import { Button } from 'reactstrap';
 
 import style from '~/styles/ny-term.module.css';
 
 export const loader: LoaderFunction = ({ params }: LoaderFunctionArgs) => {
-  return json({ termId: params.termId });
+  return { termId: params.termId };
 };
 
 export default function NyTermOpprettet() {

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -1,5 +1,4 @@
 import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node';
-import { json } from '@remix-run/node';
 import { Form, useLoaderData, useNavigation } from '@remix-run/react';
 import type { ChangeEvent } from 'react';
 import { Button, Label, Row } from 'reactstrap';
@@ -9,7 +8,7 @@ import { DialectInput } from '~/lib/components/dialect-input';
 import style from '~/styles/ny-term.module.css';
 
 export const loader: LoaderFunction = ({ params }: LoaderFunctionArgs) => {
-  return json({ termFromUrl: params.term });
+  return { termFromUrl: params.term };
 };
 
 export default function NyTerm() {

--- a/app/routes/termliste.tsx
+++ b/app/routes/termliste.tsx
@@ -12,7 +12,7 @@ import {
   TableSortLabel,
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-import { defer } from '@remix-run/node';
+import { data } from '@remix-run/node';
 import { Await, Link, useLoaderData, useRouteLoaderData } from '@remix-run/react';
 import type { ChangeEvent, KeyboardEvent, MouseEvent } from 'react';
 import { Suspense, useState } from 'react';
@@ -62,12 +62,7 @@ export function loader() {
     else throw new Error(`${res.status} ${res.statusText}: Feil under henting av fagfelt!`);
   });
 
-  return defer(
-    {
-      subjects: subjects,
-    },
-    { headers: { 'Cache-Control': 'max-age=3600' } },
-  );
+  return data({ subjects: subjects }, { headers: { 'Cache-Control': 'max-age=3600' } });
 }
 
 export default function Termliste() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,19 @@ import { vitePlugin as remix } from '@remix-run/dev';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+declare module '@remix-run/node' {
+  interface Future {
+    v3_singleFetch: true;
+  }
+}
+
 export default defineConfig({
   plugins: [
     remix({
       ignoredRouteFiles: ['**/*.css'],
+      future: {
+        v3_singleFetch: true,
+      },
     }),
     tsconfigPaths(),
   ],


### PR DESCRIPTION
- **Tar i bruk singleFetch, bytter ut defer for subjects**
- **Fjerner all bruk av defer og json fra @remix-run/node**

Endringer i `entry.server.tsx` dokumentert her: https://remix.run/docs/en/main/guides/single-fetch#streaming-timeout
Bruk av `data` dokumentert her: https://remix.run/docs/en/main/guides/single-fetch#enabling-single-fetch
