### PR TITLE
Henter fagfelt i loader på egen route, kaller med useFetcher

### DIFF
--- a/app/routes/api.fagfelt.tsx
+++ b/app/routes/api.fagfelt.tsx
@@ -1,0 +1,13 @@
+import { data, LoaderFunction } from '@remix-run/node';
+import { Subject } from '~/types/subject';
+
+export const loader: LoaderFunction = async () => {
+  const subjectsUrl = 'https://api.fagord.no/fagfelt/';
+
+  const subjectsResponse = await fetch(subjectsUrl);
+  if (!subjectsResponse.ok) {
+    return data({ subjects: [] as Subject[], error: true, message: 'Last fagfelt på nytt' }, { status: 500 });
+  }
+  const subjects = (await subjectsResponse.json()) as Subject[];
+  return data({ subjects, error: false, message: undefined }, { headers: { 'Cache-Control': 'max-age=3600' } });
+};

--- a/app/routes/termliste/route.tsx
+++ b/app/routes/termliste/route.tsx
@@ -3,35 +3,8 @@ import { Suspense } from 'react';
 import { Await, useNavigate, useRouteLoaderData } from '@remix-run/react';
 import type { loader as rootLoader } from '~/root';
 import Table from './table';
-import { data, LoaderFunction } from '@remix-run/node';
-import type { Subject } from '~/types/subject';
 import { Loader } from '~/lib/components/loader';
 import { ErrorMessage } from '~/lib/components/error-message';
-
-export const loader: LoaderFunction = () => {
-  const subjectsUrl = 'https://api.fagord.no/fagfelt/';
-
-  return fetch(subjectsUrl)
-    .then(async (res) => {
-      if (!res.ok) {
-        throw new Error('Kunne ikke hente fagfelt');
-      }
-      return data(
-        { success: true, subjects: res.json() as Promise<Subject[]>, message: undefined },
-        { headers: { 'Cache-Control': 'max-age=3600' } },
-      );
-    })
-    .catch(() => {
-      return data(
-        {
-          success: false,
-          subjects: [] as Subject[],
-          message: 'Kunne ikke laste fagfelt',
-        },
-        { status: 500 },
-      );
-    });
-};
 
 export default function Termliste() {
   const termsData = useRouteLoaderData<typeof rootLoader>('root');

--- a/app/routes/termliste/subject-filter/subject-filter.module.css
+++ b/app/routes/termliste/subject-filter/subject-filter.module.css
@@ -14,6 +14,13 @@
     padding: 8px;
 }
 
+.container {
+    width: 250px;
+    max-width: 95vw;
+    margin: 0;
+    padding: 8px;
+}
+
 .inlineErrorMessage {
     display: flex;
     align-items: center;

--- a/app/routes/termliste/subject-filter/subject-filter.tsx
+++ b/app/routes/termliste/subject-filter/subject-filter.tsx
@@ -1,37 +1,43 @@
-import { Suspense } from 'react';
 import { Spinner } from '~/lib/components/spinner';
-import { Await } from '@remix-run/react';
 import style from './subject-filter.module.css';
-import { AllSubjects, type SubjectsLoaderData } from '~/types/subject';
+import { AllSubjects } from '~/types/subject';
+import { useSubjectsFetcher } from '~/routes/termliste/subject-filter/use-subjects-fetcher';
 
 type Props = {
   onChange: (subject: string) => void;
-  subjectsData: SubjectsLoaderData;
 };
 
-export const SubjectFilter = ({ onChange, subjectsData }: Props) => (
-  <Suspense fallback={<Spinner />}>
-    <Await resolve={subjectsData}>
-      {(subjectsData) =>
-        subjectsData.success ? (
-          <Suspense fallback={<Spinner />}>
-            <Await resolve={subjectsData.subjects}>
-              {(subjects) => (
-                <select className={style.subjects} onChange={(event) => onChange(event.currentTarget.value)}>
-                  {[AllSubjects, ...subjects].map((subject) => (
-                    <option key={subject.field}>{subject.field}</option>
-                  ))}
-                </select>
-              )}
-            </Await>
-          </Suspense>
-        ) : (
-          <p className={style.inlineErrorMessage}>
-            <i className="fa-solid fa-triangle-exclamation"></i>
-            {subjectsData.message}
-          </p>
-        )
-      }
-    </Await>
-  </Suspense>
-);
+export const SubjectFilter = ({ onChange }: Props) => {
+  const subjectsFetcher = useSubjectsFetcher();
+
+  function handleClick() {
+    subjectsFetcher.load('/api/fagfelt');
+  }
+
+  if (subjectsFetcher.state === 'loading')
+    return (
+      <div className={style.container}>
+        <Spinner />
+      </div>
+    );
+
+  if (subjectsFetcher.data?.error) {
+    return (
+      <button className={style.subjects} onClick={handleClick}>
+        <i className="fa-solid fa-rotate"></i> {subjectsFetcher.data.message}
+      </button>
+    );
+  }
+
+  if (subjectsFetcher.data) {
+    return (
+      <select className={style.subjects} onChange={(event) => onChange(event.currentTarget.value)}>
+        {[AllSubjects, ...subjectsFetcher.data.subjects].map((subject) => (
+          <option key={subject.field} value={subject.field}>
+            {subject.field}
+          </option>
+        ))}
+      </select>
+    );
+  }
+};

--- a/app/routes/termliste/subject-filter/use-subjects-fetcher.ts
+++ b/app/routes/termliste/subject-filter/use-subjects-fetcher.ts
@@ -1,0 +1,15 @@
+import { useFetcher } from '@remix-run/react';
+import type { loader } from '~/routes/api.fagfelt';
+import { useEffect } from 'react';
+
+export function useSubjectsFetcher() {
+  const fetcher = useFetcher<typeof loader>();
+
+  useEffect(() => {
+    if (!fetcher.data && fetcher.state === 'idle') {
+      fetcher.load('/api/fagfelt');
+    }
+  }, [fetcher]);
+
+  return fetcher;
+}

--- a/app/routes/termliste/table.tsx
+++ b/app/routes/termliste/table.tsx
@@ -18,12 +18,10 @@ import {
 } from '@tanstack/react-table';
 import { TranslationFilter } from './translation-filter/translation-filter';
 import { Fragment, useState, type KeyboardEvent } from 'react';
-import { useLoaderData } from '@remix-run/react';
 import style from '~/routes/termliste/termliste.module.css';
 import '~/routes/termliste/termliste.module.css';
 import { Paginator } from '~/routes/termliste/paginator/paginator';
 import { SubjectFilter } from './subject-filter/subject-filter';
-import { loader } from '~/routes/termliste/route';
 import { subjectFilter, translationFilter } from '~/routes/termliste/filters';
 import { TermDetaljer } from './term-detaljer/term-detaljer';
 
@@ -94,7 +92,6 @@ type Props = {
 };
 
 export default function Table({ terms }: Props) {
-  const subjectsData = useLoaderData<typeof loader>();
   const [transFilter, setTransFilter] = useState<any>(['all']);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
@@ -140,10 +137,7 @@ export default function Table({ terms }: Props) {
       <div className="col-12 col-lg-10 mx-auto">
         <div className={style.header}>
           <TranslationFilter setTransFilter={setTransFilter} />
-          <SubjectFilter
-            onChange={(subject) => table.getColumn('field')?.setFilterValue(subject)}
-            subjectsData={subjectsData}
-          />
+          <SubjectFilter onChange={(subject) => table.getColumn('field')?.setFilterValue(subject)} />
         </div>
         <div className={style.tableScrollWrapper}>
           <table className={style.table}>


### PR DESCRIPTION
Vi hadde en kunstig dataflyt hvor `termliste/route.tsx` definerte `loader` for fagfelt, men denne ble bruke nede i `SubjectsFilter`. Det var dermed vanskelig å avgrense eventuelle feil ved henting av fagfelt til kun denne komponenten (kunne f.eks. ikke bruke `ErrorBoundary`). Ville dessuten unngå å hente både fagfelt og termer i samme `loader`.

Skiller derfor ut en egen _route_ med `loader` som laster fagfelt, og kaller denne eksplisitt i `SubjectsFilter`. Denne blir dermed ansvarlig for å hente sine egne data, litt som en selvstendig øy.