### PR TITLE
Rust-API på termside

### DIFF
--- a/app/routes/term.$termId.tsx
+++ b/app/routes/term.$termId.tsx
@@ -194,6 +194,7 @@ export const VariantCloud = ({ variants }: VariantCloudProps) => {
             value: displayed_variant,
             key: displayed_variant,
             props: {
+              id: v.id.toString(),
               term: v.text,
               dialect: v.dialect,
             },
@@ -203,10 +204,8 @@ export const VariantCloud = ({ variants }: VariantCloudProps) => {
         onClick={(tag: Tag) => {
           const formData = new FormData();
           if (tag.props) {
-            const { term, dialect } = tag.props as { term: string; dialect: 'nb' | 'nn' };
-            formData.append('term', term);
-            formData.append('dialect', dialect);
-
+            const { id } = tag.props as { id: string };
+            formData.append('variantId', id);
             fetcher.submit(formData, { method: 'post', action: 'varianter/stem' });
             dialogRef.current?.showModal();
           }

--- a/app/routes/term.$termId.tsx
+++ b/app/routes/term.$termId.tsx
@@ -33,7 +33,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
     throw new Response('Termen finnes ikke', { status: 404 });
   }
 
-  return termResponse.json();
+  return termResponse.json() as Promise<Term>;
 };
 
 export default function Term() {
@@ -177,8 +177,8 @@ export const VariantCloud = ({ variants }: VariantCloudProps) => {
   };
 
   const renderTermNoDuplicates = (variant: Variant): string => {
-    if (variants.filter((v) => v.term === variant.term).length > 1) return variant.term + ' (' + variant.dialect + ')';
-    return variant.term;
+    if (variants.filter((v) => v.text === variant.text).length > 1) return variant.text + ' (' + variant.dialect + ')';
+    return variant.text;
   };
 
   return (
@@ -194,7 +194,7 @@ export const VariantCloud = ({ variants }: VariantCloudProps) => {
             value: displayed_variant,
             key: displayed_variant,
             props: {
-              term: v.term,
+              term: v.text,
               dialect: v.dialect,
             },
             count: v.votes,
@@ -217,7 +217,7 @@ export const VariantCloud = ({ variants }: VariantCloudProps) => {
           <p>Stemmer...</p>
         ) : (
           <p>
-            Du har gitt én stemme til <em>«{fetcher.data?.term}»</em>.
+            Du har gitt én stemme til <em>«{fetcher.data?.text}»</em>.
           </p>
         )}
       </Dialog>

--- a/app/routes/term.$termId.tsx
+++ b/app/routes/term.$termId.tsx
@@ -53,7 +53,7 @@ export default function Term() {
           </nav>
         </div>
         <TermComponent term={term} />
-        {term.variants ? <VariantCloud variants={term.variants} /> : null}
+        <VariantCloud variants={term.variants} />
       </div>
     </main>
   );

--- a/app/routes/term.$termId.varianter.legg-til.tsx
+++ b/app/routes/term.$termId.varianter.legg-til.tsx
@@ -7,7 +7,8 @@ export async function action({ request, params }: Route.ActionArgs) {
   const formData = await request.formData();
   const { termId } = params;
   const submitVariant = Object.fromEntries(formData) as unknown as SubmitVariant;
-  const termsApiUrl = `https://www.api.fagord.no/termer/${termId}/varianter`;
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const termsApiUrl = `${FAGORD_RUST_API_URL}/terms/${termId}/variants`;
 
   const res = await fetch(termsApiUrl, {
     headers: {
@@ -21,11 +22,5 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!res.ok) {
     throw Error(res.status.toString() + ' ' + res.statusText);
   }
-  await res.json();
   return redirect(`/term/${termId}`);
-}
-
-export async function clientAction({ serverAction }: Route.ClientActionArgs) {
-  localStorage.removeItem('terms');
-  await serverAction();
 }

--- a/app/routes/term.$termId.varianter.stem.tsx
+++ b/app/routes/term.$termId.varianter.stem.tsx
@@ -1,28 +1,21 @@
-import type { SubmitVariant } from '~/types/term';
 import type { Route } from './+types/term.$termId.varianter.stem';
 
-export async function action({ request, params }: Route.ActionArgs) {
+export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const { termId } = params;
-  const submitVariant = Object.fromEntries(formData) as unknown as SubmitVariant;
-  const termsApiUrl = `https://www.api.fagord.no/termer/${termId}/varianter`;
+  const { variantId } = Object.fromEntries(formData) as unknown as { variantId: number };
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const termsApiUrl = `${FAGORD_RUST_API_URL}/variants/${variantId}`;
 
   const res = await fetch(termsApiUrl, {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-    method: 'PUT',
-    body: JSON.stringify(submitVariant),
+    method: 'POST',
   });
 
   if (!res.ok) {
     throw Error(res.status.toString() + ' ' + res.statusText);
   }
   return await res.json();
-}
-
-export async function clientAction({ serverAction }: Route.ClientActionArgs) {
-  localStorage.removeItem('terms');
-  return serverAction();
 }

--- a/app/types/term.ts
+++ b/app/types/term.ts
@@ -22,4 +22,7 @@ export type Language = Pick<Term, 'en' | 'nb' | 'nn'>;
 
 export type SubmitTerm = Partial<Term>;
 
-export type SubmitVariant = Partial<Variant>;
+export interface SubmitVariant {
+  term: string;
+  dialect: 'nb' | 'nn';
+}

--- a/app/types/term.ts
+++ b/app/types/term.ts
@@ -12,9 +12,10 @@ export interface Term {
 }
 
 export interface Variant {
-  term: string;
+  id: number;
+  text: string;
   dialect: 'nb' | 'nn';
-  votes?: number;
+  votes: number;
 }
 
 export type Language = Pick<Term, 'en' | 'nb' | 'nn'>;


### PR DESCRIPTION
Tar i bruk Rust-API på termsiden. Dette gjelder henting av term og varianter, legg til variant, og stem på variant.

- **Henter term med detaljer fra fagord-rust-api**
- **Bruker varianter fra Rust-API**
- **Publiserer termer mot Rust-API**
- **Stemmer på variant via Rust-API**
