### PR TITLE
Henter hele termlisten fra Rust-API

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,42 +7,8 @@ import { ErrorMessage } from '~/lib/components/error-message';
 import { Footer } from '~/lib/components/footer';
 import { Header } from '~/lib/components/header';
 import { splashscreens } from '~/links/splashscreens';
-import type { Term } from '~/types/term';
-import type { Route } from './+types/root';
 
 import appStylesHref from './app.css?url';
-
-export const loader = () => {
-  const termsUrl = 'https://api.fagord.no/termer/';
-  const terms = fetch(termsUrl).then(async (res) => {
-    if (!res.ok) {
-      throw new Response('Klarte ikke å hente termer', { status: 500 });
-    }
-    return (await res.json()) as Term[];
-  });
-
-  return {
-    terms,
-  };
-};
-
-export const clientLoader = ({ serverLoader }: Route.ClientLoaderArgs) => {
-  const cachedTerms = localStorage.getItem('terms');
-  if (cachedTerms) {
-    return {
-      terms: JSON.parse(cachedTerms) as Term[],
-    };
-  }
-
-  return (serverLoader() as Promise<{ terms: Promise<Term[]> }>).then((data) => {
-    data.terms.then((terms) => {
-      localStorage.setItem('terms', JSON.stringify(terms));
-    });
-    return data;
-  });
-};
-
-clientLoader.hydrate = true;
 
 export function ErrorBoundary() {
   const error = useRouteError();

--- a/app/routes/api.termliste.søk.($term).tsx
+++ b/app/routes/api.termliste.søk.($term).tsx
@@ -2,14 +2,19 @@ import type { Term } from '~/types/term';
 import Fuse from 'fuse.js/basic';
 import type { Route } from './+types/api.termliste.søk.($term)';
 
-export async function clientAction({ request }: Route.ClientActionArgs) {
+export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData();
   const { q } = Object.fromEntries(formData) as { q: string };
-  const cachedTerms = localStorage.getItem('terms');
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const termsApiUrl = `${FAGORD_RUST_API_URL}/terms`;
+  const termsResponse = await fetch(termsApiUrl);
 
-  if (q && cachedTerms) {
-    const terms = JSON.parse(cachedTerms) as Term[];
+  if (!termsResponse.ok) {
+    throw new Response('Klarte ikke å hente termer', { status: 500 });
+  }
+  const terms = (await termsResponse.json()) as Term[];
 
+  if (q && terms) {
     const fuse = new Fuse(terms, {
       keys: ['en', 'nb', 'nn'],
       threshold: 0.3, // Adjust the threshold for fuzzy matching,

--- a/app/routes/term.$termId.tsx
+++ b/app/routes/term.$termId.tsx
@@ -33,7 +33,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
     throw new Response('Termen finnes ikke', { status: 404 });
   }
 
-  return termResponse.json() as Promise<Term>;
+  return (await termResponse.json()) as Term;
 };
 
 export default function Term() {

--- a/app/routes/termliste/route.tsx
+++ b/app/routes/termliste/route.tsx
@@ -5,42 +5,20 @@ import Table from './table';
 import { Loader } from '~/lib/components/loader';
 import { ErrorMessage } from '~/lib/components/error-message';
 import { Term } from '~/types/term';
-import { Route } from './+types/route';
 
-export const loader = () => {
-  const termsUrl = 'https://api.fagord.no/termer/';
-  const terms = fetch(termsUrl).then(async (res) => {
-    if (!res.ok) {
-      throw new Response('Klarte ikke å hente termer', { status: 500 });
-    }
-    return (await res.json()) as Term[];
-  });
+export async function loader() {
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const termsApiUrl = `${FAGORD_RUST_API_URL}/terms`;
+  const termsResponse = await fetch(termsApiUrl);
 
-  return {
-    terms,
-  };
-};
-
-export const clientLoader = ({ serverLoader }: Route.ClientLoaderArgs) => {
-  const cachedTerms = localStorage.getItem('terms');
-  if (cachedTerms) {
-    return {
-      terms: JSON.parse(cachedTerms) as Term[],
-    };
+  if (!termsResponse.ok) {
+    throw new Response('Klarte ikke å hente termer', { status: 500 });
   }
-
-  return (serverLoader() as Promise<{ terms: Promise<Term[]> }>).then((data) => {
-    data.terms.then((terms) => {
-      localStorage.setItem('terms', JSON.stringify(terms));
-    });
-    return data;
-  });
-};
-
-clientLoader.hydrate = true;
+  return (await termsResponse.json()) as Term[];
+}
 
 export default function Termliste() {
-  const { terms } = useLoaderData<typeof loader>();
+  const terms = useLoaderData<typeof loader>();
   return (
     <Suspense fallback={<Loader />}>
       <Await resolve={terms}>{(resolvedTerms) => <Table terms={resolvedTerms} />}</Await>

--- a/app/routes/termliste/term-detaljer/term-detaljer.tsx
+++ b/app/routes/termliste/term-detaljer/term-detaljer.tsx
@@ -48,7 +48,7 @@ export const TermDetaljer = ({ term }: { term: Term }) => {
         )}
         <tr>
           <td colSpan={2}>
-            <Link className="btn btn-outline-dark btn-sm" to={'/term/' + term._id} role="button">
+            <Link className="btn btn-outline-dark btn-sm" to={'/term/' + term.slug} role="button">
               Til termside
             </Link>
           </td>


### PR DESCRIPTION
Henter hele termlisten fra Rust-API. Herunder:
* Laster termliste-tabellen fra Rust-API
* Fjerner global henting av termer, slik at den finnes i `localStorage` til enhver tid
* Søkefeltet spør også mot Rust-API