### PR TITLE
Cacher termer i klienten for raskt søk

### DIFF
--- a/app/lib/components/search.tsx
+++ b/app/lib/components/search.tsx
@@ -52,7 +52,7 @@ export function Search() {
         <nav className={styles.resultDropdown} hidden={!resultsOpen}>
           <ul className={styles.results}>
             {fetcher.data.searchResult.map((term: Term) => (
-              <SearchResult term={term} key={term._id} />
+              <SearchResult term={term} key={term.slug} />
             ))}
           </ul>
           <NoOptionsMessage q={searchParams.get('q')} />


### PR DESCRIPTION
- **clientAction ifb. term-søk**
- **5 min varighet på søkecache**
- **Trekker ut felles fuse-kode mellom action og clientAction**
- **Bruker slug som key i søkeresultat**
