### PR TITLE
Bruker slug og subjects konsekvent, tester kjører grønt

### DIFF
--- a/app/lib/components/share-term-button.client.tsx
+++ b/app/lib/components/share-term-button.client.tsx
@@ -11,7 +11,7 @@ export const ShareTermButton = ({ term }: Props) => {
   const termShareData = {
     title: 'Fagord',
     text: term.en + fieldSpecStr,
-    url: 'https://www.fagord.no/term/' + term._id,
+    url: 'https://www.fagord.no/term/' + term.slug,
   };
 
   return (

--- a/app/lib/termliste/table.tsx
+++ b/app/lib/termliste/table.tsx
@@ -89,10 +89,10 @@ const columns = [
 
 type Props = {
   terms: Term[];
-  fields: Promise<Subject[]>;
+  subjects: Promise<Subject[]>;
 };
 
-export default function Table({ terms, fields }: Props) {
+export default function Table({ terms, subjects }: Props) {
   const [transFilter, setTransFilter] = useState<any>(['all']);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
@@ -138,7 +138,10 @@ export default function Table({ terms, fields }: Props) {
       <div className="col-12 col-lg-10 mx-auto">
         <div className={style.header}>
           <TranslationFilter setTransFilter={setTransFilter} />
-          <SubjectFilter subjects={fields} onChange={(subject) => table.getColumn('field')?.setFilterValue(subject)} />
+          <SubjectFilter
+            subjects={subjects}
+            onChange={(subject) => table.getColumn('field')?.setFilterValue(subject)}
+          />
         </div>
         <div className={style.tableScrollWrapper}>
           <table className={style.table}>

--- a/app/routes/termliste.tsx
+++ b/app/routes/termliste.tsx
@@ -15,7 +15,7 @@ export async function loader() {
     }
     return res.json() as Promise<Term[]>;
   });
-  const fieldsResponse = fetch(`${FAGORD_RUST_API_URL}/fields`).then((res) => {
+  const subjectsResponse = fetch(`${FAGORD_RUST_API_URL}/fields`).then((res) => {
     if (!res.ok) {
       throw data('Klarte ikke å hente fagfelt', { status: 500 });
     }
@@ -24,7 +24,7 @@ export async function loader() {
 
   return {
     terms: termsResponse,
-    fields: fieldsResponse,
+    subjects: subjectsResponse,
   };
 }
 
@@ -35,10 +35,10 @@ export function headers(_: Route.HeadersArgs) {
 }
 
 export default function Termliste() {
-  const { terms, fields } = useLoaderData<typeof loader>();
+  const { terms, subjects } = useLoaderData<typeof loader>();
   return (
     <Suspense fallback={<Loader />}>
-      <Await resolve={terms}>{(resolvedTerms) => <Table terms={resolvedTerms} fields={fields} />}</Await>
+      <Await resolve={terms}>{(resolvedTerms) => <Table terms={resolvedTerms} subjects={subjects} />}</Await>
     </Suspense>
   );
 }

--- a/app/types/term.ts
+++ b/app/types/term.ts
@@ -1,5 +1,4 @@
 export interface Term {
-  _id: string;
   slug: string;
   en: string;
   nb: string;

--- a/test/routes/hjem.test.tsx
+++ b/test/routes/hjem.test.tsx
@@ -1,10 +1,11 @@
 import { createRoutesStub } from 'react-router';
 import Hjem from '~/routes/hjem';
-import Termliste from '~/routes/route';
+import Termliste from '~/routes/termliste';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, test } from 'vitest';
 import { createValidTerms } from '../test-data/term';
+import { createValidSubjects } from '../test-data/subjects';
 
 afterEach(cleanup);
 
@@ -34,16 +35,7 @@ describe('Tester innhold på og navigasjon fra Hjem-siden', () => {
         loader() {
           return {
             terms: createValidTerms(),
-          };
-        },
-      },
-      {
-        path: '/api/fagfelt',
-        loader() {
-          return {
-            subjects: [],
-            error: false,
-            message: undefined,
+            subjects: createValidSubjects(),
           };
         },
       },
@@ -51,7 +43,7 @@ describe('Tester innhold på og navigasjon fra Hjem-siden', () => {
 
     render(<Stub initialEntries={['/hjem']} />);
 
-    userEvent.click(screen.getByText('Til termliste!'));
+    await userEvent.click(screen.getByText('Til termliste!'));
     await waitFor(() => screen.findByText('Engelsk'));
   });
 });

--- a/test/routes/term.$termId.endre.test.tsx
+++ b/test/routes/term.$termId.endre.test.tsx
@@ -25,7 +25,7 @@ describe('Tester innsending på Endre-siden', () => {
         loader() {
           return {
             terms: createValidTerms(),
-            term: createValidTerms().find((term) => term._id === termId),
+            term: createValidTerms().find((term) => term.slug === termId),
           };
         },
       },

--- a/test/test-data/subjects.ts
+++ b/test/test-data/subjects.ts
@@ -1,0 +1,15 @@
+import { Subject } from '~/types/subject';
+
+export function createValidSubjects(): Subject[] {
+  return [
+    {
+      name: 'Biologi',
+    },
+    {
+      name: 'IT',
+    },
+    {
+      name: 'Materialteknologi',
+    },
+  ];
+}

--- a/test/test-data/term.ts
+++ b/test/test-data/term.ts
@@ -3,13 +3,13 @@ import { Term } from '~/types/term';
 export function createValidTerms(): Term[] {
   return [
     {
-      _id: 'cortex_sub',
+      slug: 'cortex_sub',
       en: 'cortex',
       nb: 'hjernebark',
       nn: 'hjernebork',
       variants: [
-        { term: 'hjernebark', dialect: 'nb', votes: 1 },
-        { term: 'hjernebork', dialect: 'nn', votes: 1 },
+        { id: 1, text: 'hjernebark', dialect: 'nb', votes: 1 },
+        { id: 2, text: 'hjernebork', dialect: 'nn', votes: 1 },
       ],
       field: 'Biologi',
       subfield: 'Nevrovitenskap',
@@ -18,13 +18,13 @@ export function createValidTerms(): Term[] {
       definition: 'Ytre, grå substans av nerveceller som dekker overflata på hjernen',
     },
     {
-      _id: 'archaea_sub',
+      slug: 'archaea_sub',
       en: 'archaea',
       nb: 'arkebakterier',
       nn: 'arkebakteriar',
       variants: [
-        { term: 'arkebakterier', dialect: 'nb', votes: 1 },
-        { term: 'arkebakteriar', dialect: 'nn', votes: 1 },
+        { id: 3, text: 'arkebakterier', dialect: 'nb', votes: 1 },
+        { id: 4, text: 'arkebakteriar', dialect: 'nn', votes: 1 },
       ],
       field: 'Biologi',
       subfield: 'Mikrobiologi',
@@ -34,14 +34,14 @@ export function createValidTerms(): Term[] {
         'Mikroskopiske, encellede, prokaryote organismer som utseendemessig likner bakterier, men har andre biokjemiske komponenter i cellevegg og ulik form og størrelse på ribosomene.',
     },
     {
-      _id: 'benchmark_sub',
+      slug: 'benchmark_sub',
       en: 'benchmark',
       nb: 'ytelsestest',
       nn: 'ytingstest',
       variants: [
-        { term: 'ytelsestest', dialect: 'nb', votes: 1 },
-        { term: 'ytingstest', dialect: 'nn', votes: 1 },
-        { term: 'temperaturmåling', dialect: 'nb', votes: 1 },
+        { id: 5, text: 'ytelsestest', dialect: 'nb', votes: 1 },
+        { id: 6, text: 'ytingstest', dialect: 'nn', votes: 1 },
+        { id: 7, text: 'temperaturmåling', dialect: 'nb', votes: 1 },
       ],
       field: 'IT',
       subfield: 'Programvare',
@@ -51,13 +51,13 @@ export function createValidTerms(): Term[] {
         'Testing for å måle ytelsen til et programvareprodukt. Måling av systemets svartider eller testing av systemets kapasitet under gitte krav til svartider.',
     },
     {
-      _id: 'abrasive_sub',
+      slug: 'abrasive_sub',
       en: 'abrasive',
       nb: 'slipemiddel',
       nn: 'slipemiddel',
       variants: [
-        { term: 'slipemiddel', dialect: 'nb', votes: 7 },
-        { term: 'slipemiddel', dialect: 'nn', votes: 7 },
+        { id: 8, text: 'slipemiddel', dialect: 'nb', votes: 7 },
+        { id: 9, text: 'slipemiddel', dialect: 'nn', votes: 7 },
       ],
       field: 'Materialteknologi',
       subfield: 'Materialer',


### PR DESCRIPTION
Vi har tidligere brukt `_id`, men `id` har en annen rolle i Fagord-API-et nå. Bruker derfor `slug` over det hele. Mulig at jeg bytter navn på denne senere.

Bruker også `subjects` i hele appen, som er mer presist enn det generiske `fields`. Vurderer å gjøre tilsvarende endring i backend på sikt.

Tester kjører nå grønt.