### PR TITLE
Termliste laster uten JS

### DIFF
--- a/app/lib/components/search.tsx
+++ b/app/lib/components/search.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type MouseEvent, useState } from 'react';
+import { type ChangeEvent, useState } from 'react';
 import { Form, Link, useFetcher, useLocation, useNavigation, useSearchParams } from 'react-router';
 
 import styles from '~/styles/search.module.css';
@@ -28,7 +28,7 @@ export function Search() {
 
   return (
     <div className={styles.wrapper}>
-      <Form method="get" id="search-form" role="search" action="termliste">
+      <Form method="get" id="search-form" role="search" action="/termliste">
         <input
           id="q"
           defaultValue={query}

--- a/app/lib/termliste/subject-filter/subject-filter.tsx
+++ b/app/lib/termliste/subject-filter/subject-filter.tsx
@@ -1,37 +1,19 @@
 import style from './subject-filter.module.css';
 import { AllSubjects, Subject } from '~/types/subject';
-import { Suspense } from 'react';
-import { Await } from 'react-router';
 
 type Props = {
-  subjects: Promise<Subject[]>;
+  subjects: Subject[];
   onChange: (subject: string) => void;
 };
 
 export const SubjectFilter = ({ onChange, subjects }: Props) => {
   return (
-    <Suspense fallback={<Loader />}>
-      <Await resolve={subjects}>
-        {(subjects) => (
-          <select className={style.subjects} onChange={(event) => onChange(event.currentTarget.value)}>
-            {[AllSubjects, ...subjects].map((subject) => (
-              <option key={subject.name} value={subject.name}>
-                {subject.name}
-              </option>
-            ))}
-          </select>
-        )}
-      </Await>
-    </Suspense>
+    <select className={style.subjects} onChange={(event) => onChange(event.currentTarget.value)}>
+      {[AllSubjects, ...subjects].map((subject) => (
+        <option key={subject.name} value={subject.name}>
+          {subject.name}
+        </option>
+      ))}
+    </select>
   );
 };
-
-function Loader() {
-  return (
-    <div className={style.skeleton}>
-      <p>
-        <i className="fa-solid fa-spinner fa-spin" /> Henter fagfelt
-      </p>
-    </div>
-  );
-}

--- a/app/lib/termliste/table.tsx
+++ b/app/lib/termliste/table.tsx
@@ -89,7 +89,7 @@ const columns = [
 
 type Props = {
   terms: Term[];
-  subjects: Promise<Subject[]>;
+  subjects: Subject[];
 };
 
 export default function Table({ terms, subjects }: Props) {

--- a/app/routes/termliste._index.tsx
+++ b/app/routes/termliste._index.tsx
@@ -1,0 +1,51 @@
+import { useLoaderData, useNavigate } from 'react-router';
+import Table from '~/lib/termliste/table';
+import { ErrorMessage } from '~/lib/components/error-message';
+import { Term } from '~/types/term';
+import { Route } from './+types/termliste._index';
+import { Subject } from '~/types/subject';
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const url = new URL(request.url);
+  const q = url.searchParams.get('q');
+
+  const termsResponse = await fetch(
+    `${FAGORD_RUST_API_URL}/terms${q ? `?q=${encodeURIComponent(q)}` : ''}`,
+  );
+  if (!termsResponse.ok) {
+    throw new Response('Klarte ikke å hente termer', { status: 500 });
+  }
+  const terms: Term[] = await termsResponse.json();
+
+  const subjectsResponse = await fetch(`${FAGORD_RUST_API_URL}/fields`);
+  if (!subjectsResponse.ok) {
+    throw new Response('Klarte ikke å hente fagfelt', { status: 500 });
+  }
+  const subjects: Subject[] = await subjectsResponse.json();
+
+  return { terms, subjects };
+}
+
+export function headers(_: Route.HeadersArgs) {
+  return {
+    'Cache-Control': 'public, max-age=300, s-maxage=600',
+  };
+}
+
+export default function Termliste() {
+  const { terms, subjects } = useLoaderData<typeof loader>();
+  return <Table terms={terms} subjects={subjects} />;
+}
+
+export function ErrorBoundary() {
+  const navigate = useNavigate();
+  return (
+    <ErrorMessage>
+      <p>Klarte ikke å hente termliste!</p>
+      <button className="btn btn-outline-dark" onClick={() => navigate('/termliste')}>
+        Last inn siden på nytt
+      </button>
+    </ErrorMessage>
+  );
+}

--- a/app/routes/termliste.tsx
+++ b/app/routes/termliste.tsx
@@ -1,59 +1,9 @@
-import { Suspense } from 'react';
-import { Await, data, useLoaderData, useNavigate } from 'react-router';
-import Table from '~/lib/termliste/table';
+import { Outlet, useNavigation } from 'react-router';
 import { Loader } from '~/lib/components/loader';
-import { ErrorMessage } from '~/lib/components/error-message';
-import { Term } from '~/types/term';
-import { Route } from './+types/termliste';
-import { Subject } from '~/types/subject';
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
-  const url = new URL(request.url);
-  const q = url.searchParams.get('q');
-  const termsUrl = q ? `${FAGORD_RUST_API_URL}/terms?q=${encodeURIComponent(q)}` : `${FAGORD_RUST_API_URL}/terms`;
-  const termsResponse = fetch(termsUrl).then((res) => {
-    if (!res.ok) {
-      throw new Response('Klarte ikke å hente termer', { status: 500 });
-    }
-    return res.json() as Promise<Term[]>;
-  });
-  const subjectsResponse = fetch(`${FAGORD_RUST_API_URL}/fields`).then((res) => {
-    if (!res.ok) {
-      throw data('Klarte ikke å hente fagfelt', { status: 500 });
-    }
-    return res.json() as Promise<Subject[]>;
-  });
+export default function TermlisteLayout() {
+  const navigation = useNavigation();
+  const isLoading = navigation.state === 'loading';
 
-  return {
-    terms: termsResponse,
-    subjects: subjectsResponse,
-  };
-}
-
-export function headers(_: Route.HeadersArgs) {
-  return {
-    'Cache-Control': 'public, max-age=300, s-maxage=600',
-  };
-}
-
-export default function Termliste() {
-  const { terms, subjects } = useLoaderData<typeof loader>();
-  return (
-    <Suspense fallback={<Loader />}>
-      <Await resolve={terms}>{(resolvedTerms) => <Table terms={resolvedTerms} subjects={subjects} />}</Await>
-    </Suspense>
-  );
-}
-
-export function ErrorBoundary() {
-  const navigate = useNavigate();
-  return (
-    <ErrorMessage>
-      <p>Klarte ikke å hente termliste!</p>
-      <button className="btn btn-outline-dark" onClick={() => navigate('/termliste')}>
-        Last inn siden på nytt
-      </button>
-    </ErrorMessage>
-  );
+  return isLoading ? <Loader /> : <Outlet />;
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
+    "dev:prod-api": "FAGORD_RUST_API_DOMAIN=https://rust-api.fagord.no react-router dev",
     "start": "react-router-serve build/server/index.js",
     "typecheck": "react-router typegen && tsc",
     "prettier": "prettier --write \"app/**/*.{ts,tsx,css}\"",

--- a/test/routes/hjem.test.tsx
+++ b/test/routes/hjem.test.tsx
@@ -1,11 +1,8 @@
 import { createRoutesStub } from 'react-router';
 import Hjem from '~/routes/hjem';
-import Termliste from '~/routes/termliste';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, test } from 'vitest';
-import { createValidTerms } from '../test-data/term';
-import { createValidSubjects } from '../test-data/subjects';
 
 afterEach(cleanup);
 
@@ -24,6 +21,9 @@ describe('Tester innhold på og navigasjon fra Hjem-siden', () => {
   });
 
   test('Kan navigere fra /hjem til /termliste', async () => {
+    function TermlistePage() {
+      return <h1>Termliste</h1>;
+    }
     const Stub = createRoutesStub([
       {
         path: '/hjem',
@@ -31,19 +31,13 @@ describe('Tester innhold på og navigasjon fra Hjem-siden', () => {
       },
       {
         path: '/termliste',
-        Component: Termliste,
-        loader() {
-          return {
-            terms: createValidTerms(),
-            subjects: createValidSubjects(),
-          };
-        },
+        Component: TermlistePage,
       },
     ]);
 
     render(<Stub initialEntries={['/hjem']} />);
 
     await userEvent.click(screen.getByText('Til termliste!'));
-    await waitFor(() => screen.findByText('Engelsk'));
+    await waitFor(() => screen.findByText('Termliste'));
   });
 });

--- a/test/routes/termliste.test.tsx
+++ b/test/routes/termliste.test.tsx
@@ -1,5 +1,5 @@
 import { createRoutesStub } from 'react-router';
-import Termliste from '~/routes/termliste';
+import Termliste from '~/routes/termliste._index';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, test } from 'vitest';
 import { createValidTerms } from '../test-data/term';


### PR DESCRIPTION
Termlisten skal laste også for brukere som har deaktivert JavaScript. Samtidig ønsker jeg at brukere med JavaScript skal se at sidenavigasjonen skjer med en gang, og vil derfor vise et laste-ikon. Oppnår dette med:
* Flytte `<Loader />` for termliste ut i en `layout route`
* Bruke `await` i `loader` på `/termliste`
* Fjerne bruken av `Suspense` og `Await` i termlisten