### PR TITLE
Gjør minimumReleaseAge eksplisitt og legg til Dependabot-cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Vent litt over pnpm sin minimumReleaseAge (3 dager) før PR-er åpnes,
+    # slik at Dependabot ikke foreslår versjoner som CI-bygget vil underkjenne.
+    cooldown:
+      default-days: 4
     groups:
       # Group all patch and minor updates together
       minor-and-patch:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 allowBuilds:
   '@swc/core': true
   esbuild: true
+
+# Supply chain-beskyttelse: vent 3 dager (4320 min) etter at en versjon er
+# publisert før den kan installeres. Gjør pnpm v11-defaulten (1 dag) eksplisitt
+# og synlig, slik at kompromitterte utgivelser rekker å bli oppdaget og trukket.
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Bakgrunn

Bygget på Dependabot-PR-er (f.eks. #326) feilet med `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. Årsaken er at pnpm v11 har en innebygd supply chain-policy, `minimumReleaseAge` (default 1 dag), som avviser pakkeversjoner publisert mindre enn ett døgn før installasjon. Dependabot åpnet PR-en for tidlig, så CI traff vinduet og `pnpm install --frozen-lockfile` ble underkjent.

To ting manglet:
1. Regelen var en implisitt pnpm-default – ikke synlig i repoet, og dermed lett å bli overrasket av.
2. Dependabot foreslo versjoner som var garantert å bli underkjent av CI.

## Endringer

- **`pnpm-workspace.yaml`**: `minimumReleaseAge: 4320` (3 dager) gjør policyen eksplisitt. Den gjelder nå identisk lokalt og på CI, uavhengig av pnpm-versjonens default.
- **`.github/dependabot.yml`**: `cooldown.default-days: 4` – Dependabot venter én dag over pnpm-terskelen før PR-er åpnes, så de aldri treffer blokkeringen.

## Hvorfor 3 dager

Supply chain-angrep (kompromittert pakke) oppdages og trekkes nesten alltid innen få dager. 3 dager dekker en helg og fanger praktisk talt alle tilbaketrekkinger, uten unødig venting for et hobbyprosjekt uten kritisk funksjonalitet.

Merk: `cooldown` gjelder ikke sikkerhetsoppdateringer – de åpnes fortsatt umiddelbart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)