### PR TITLE
Vis temasider: liste og enkeltvisning

### DIFF
--- a/app/lib/nav-links.ts
+++ b/app/lib/nav-links.ts
@@ -17,7 +17,7 @@ export const navLinks: NavItem[] = [
     text: 'Ny term',
   },
   {
-    address: '/temasider/ny',
+    address: '/temasider',
     icon: 'fa-graduation-cap',
     text: 'Temasider',
   },

--- a/app/routes/temasider.$slug.tsx
+++ b/app/routes/temasider.$slug.tsx
@@ -1,0 +1,84 @@
+import { isRouteErrorResponse, Link, useLoaderData, useRouteError } from 'react-router';
+import Markdown from 'react-markdown';
+
+import type { Route } from './+types/temasider.$slug';
+import style from '~/styles/temasider.module.css';
+import type { Article } from '~/types/article';
+
+export const meta = ({ data }: Route.MetaArgs) => [
+  { title: data ? `${data.title} – Fagord` : 'Temaside – Fagord' },
+];
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const { slug } = params;
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles/${slug}`);
+  if (!response.ok) {
+    throw new Response('Temasiden finnes ikke', { status: 404 });
+  }
+
+  return (await response.json()) as Article;
+};
+
+export function headers(_: Route.HeadersArgs) {
+  return {
+    'Cache-Control': 'public, max-age=300, s-maxage=600',
+  };
+}
+
+export default function Temaside() {
+  const article = useLoaderData<typeof loader>();
+
+  return (
+    <main className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto">
+        <nav aria-label="breadcrumb" style={{ color: 'white' }}>
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link to="/temasider">Temasider</Link>
+            </li>
+            <li className="breadcrumb-item active">{article.title}</li>
+          </ol>
+        </nav>
+
+        <article className={style.preview}>
+          <p className="text-muted">
+            av <span>{article.author}</span>
+          </p>
+          <Markdown>{article.content}</Markdown>
+        </article>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <div className="container my-3">
+        <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+          <h1>Ops! Her var det ingenting!</h1>
+          <p>Vi fant ikke temasiden du lette etter. Er du sikker på at den finnes?</p>
+          <Link to="/temasider">
+            <button className="btn btn-outline-light">Tilbake til temasidene</button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <h1>Her gikk noe galt!</h1>
+        <p>Noe gikk feil mens vi hentet temasiden.</p>
+        <Link to="/temasider">
+          <button className="btn btn-outline-light">Tilbake til temasidene</button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/temasider.$slug.tsx
+++ b/app/routes/temasider.$slug.tsx
@@ -5,8 +5,8 @@ import type { Route } from './+types/temasider.$slug';
 import style from '~/styles/temasider.module.css';
 import type { Article } from '~/types/article';
 
-export const meta = ({ data }: Route.MetaArgs) => [
-  { title: data ? `${data.title} – Fagord` : 'Temaside – Fagord' },
+export const meta = ({ loaderData }: Route.MetaArgs) => [
+  { title: loaderData ? `${loaderData.title} – Fagord` : 'Temaside – Fagord' },
 ];
 
 export const loader = async ({ params }: Route.LoaderArgs) => {

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -49,6 +49,12 @@ export default function Temasider() {
             ))}
           </ul>
         )}
+
+        <div className="mt-3">
+          <Link className="btn btn-outline-light" to="ny">
+            Skriv ny temaside
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -40,8 +40,10 @@ export default function Temasider() {
         ) : (
           <ul className="list-group">
             {articles.map((article) => (
-              <li key={article.slug} className="list-group-item">
-                <Link to={article.slug}>{article.title}</Link>
+              <li key={article.slug} className="list-group-item list-group-item-action position-relative">
+                <Link className="stretched-link" to={article.slug}>
+                  {article.title}
+                </Link>
                 <div className="text-muted">
                   av <span>{article.author}</span>
                 </div>

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -1,0 +1,67 @@
+import { Link, useLoaderData, useNavigate } from 'react-router';
+import type { MetaFunction } from 'react-router';
+
+import type { Route } from './+types/temasider._index';
+import { ErrorMessage } from '~/lib/components/error-message';
+import type { ArticleSummary } from '~/types/article';
+
+export const meta: MetaFunction = () => [{ title: 'Temasider – Fagord' }];
+
+export const loader = async () => {
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles`);
+  if (!response.ok) {
+    throw new Response('Klarte ikke å hente temasider', { status: 500 });
+  }
+
+  return (await response.json()) as ArticleSummary[];
+};
+
+export function headers(_: Route.HeadersArgs) {
+  return {
+    'Cache-Control': 'public, max-age=300, s-maxage=600',
+  };
+}
+
+export default function Temasider() {
+  const articles = useLoaderData<typeof loader>();
+
+  return (
+    <main className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <h1>Temasider</h1>
+        <p>Lengre artikler som forklarer et fagfelt eller et begrep nærmere.</p>
+
+        {articles.length === 0 ? (
+          <p>
+            <em>Ingen temasider er publisert ennå.</em>
+          </p>
+        ) : (
+          <ul className="list-group">
+            {articles.map((article) => (
+              <li key={article.slug} className="list-group-item">
+                <Link to={article.slug}>{article.title}</Link>
+                <div className="text-muted">
+                  av <span>{article.author}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary() {
+  const navigate = useNavigate();
+  return (
+    <ErrorMessage>
+      <p>Klarte ikke å hente temasider!</p>
+      <button className="btn btn-outline-dark" onClick={() => navigate('/temasider')}>
+        Last inn siden på nytt
+      </button>
+    </ErrorMessage>
+  );
+}

--- a/app/routes/temasider.ny.tsx
+++ b/app/routes/temasider.ny.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router';
 import type { MetaFunction } from 'react-router';
 import Markdown from 'react-markdown';
 
@@ -23,6 +24,15 @@ export default function NyTemaside() {
   return (
     <main className="container my-3">
       <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link to="/temasider">Temasider</Link>
+            </li>
+            <li className="breadcrumb-item active">Ny temaside</li>
+          </ol>
+        </nav>
+
         <h1>Ny temaside</h1>
         <p>
           Skriv artikkelen i Markdown til venstre, og se den ferdige temasiden ta form til høyre mens du skriver.

--- a/app/types/article.ts
+++ b/app/types/article.ts
@@ -1,0 +1,20 @@
+// Speiler kontrakten fra Rust-API-et. Felter som kommer fra databasen
+// beholder snake_case (created_at/updated_at/updated_by) slik de ligger på tråden.
+
+/** Det /articles returnerer per rad i listen. */
+export type ArticleSummary = {
+  slug: string;
+  title: string;
+  author: string;
+};
+
+/** Det /articles/{slug} returnerer for én temaside. */
+export type Article = {
+  slug: string;
+  title: string;
+  author: string;
+  content: string;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/test/lib/nav-links.test.ts
+++ b/test/lib/nav-links.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { navLinks } from '~/lib/nav-links';
+
+describe('Tester navigasjonslenkene', () => {
+  test('Temasider-lenken peker på listen, ikke på «ny»-skjemaet', () => {
+    const temasider = navLinks.find((lenke) => lenke.text === 'Temasider');
+    expect(temasider?.address).toBe('/temasider');
+  });
+});

--- a/test/routes/temasider.$slug.test.tsx
+++ b/test/routes/temasider.$slug.test.tsx
@@ -1,7 +1,7 @@
 import { createRoutesStub } from 'react-router';
 import Temaside, { ErrorBoundary } from '~/routes/temasider.$slug';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { createValidArticle } from '../test-data/article';
 
 afterEach(cleanup);

--- a/test/routes/temasider.$slug.test.tsx
+++ b/test/routes/temasider.$slug.test.tsx
@@ -1,0 +1,62 @@
+import { createRoutesStub } from 'react-router';
+import Temaside, { ErrorBoundary } from '~/routes/temasider.$slug';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, test } from 'vitest';
+import { createValidArticle } from '../test-data/article';
+
+afterEach(cleanup);
+
+describe('Tester visning av én temaside', () => {
+  function renderSide(article = createValidArticle()) {
+    const Stub = createRoutesStub([
+      {
+        path: '/temasider/:slug',
+        Component: Temaside,
+        loader() {
+          return article;
+        },
+      },
+    ]);
+    render(<Stub initialEntries={[`/temasider/${article.slug}`]} />);
+  }
+
+  test('Viser tittelen til temasiden', async () => {
+    renderSide();
+    await waitFor(() => screen.getByRole('heading', { name: 'Vin', level: 1 }));
+  });
+
+  test('Viser forfatteren til temasiden', async () => {
+    renderSide();
+    await waitFor(() => screen.getByText(/Isak Kyrre Lichtwarck Bjugn/));
+  });
+
+  test('Rendrer Markdown-innholdet som HTML', async () => {
+    renderSide();
+    // «## Rødvin» skal bli en overskrift, ikke rå tekst med skigard.
+    await waitFor(() => screen.getByRole('heading', { name: 'Rødvin' }));
+  });
+
+  test('Har en lenke tilbake til temaside-listen', async () => {
+    renderSide();
+    const lenke = await screen.findByRole('link', { name: /Temasider/ });
+    expect(lenke.getAttribute('href')).toBe('/temasider');
+  });
+});
+
+describe('Tester feilhåndtering for temaside som ikke finnes', () => {
+  test('ErrorBoundary viser en 404-melding ved manglende temaside', async () => {
+    const Stub = createRoutesStub([
+      {
+        path: '/temasider/:slug',
+        Component: Temaside,
+        ErrorBoundary,
+        loader() {
+          throw new Response('Temasiden finnes ikke', { status: 404 });
+        },
+      },
+    ]);
+    render(<Stub initialEntries={['/temasider/finnes-ikke']} />);
+
+    await waitFor(() => screen.getByText(/fant ikke/i));
+  });
+});

--- a/test/routes/temasider._index.test.tsx
+++ b/test/routes/temasider._index.test.tsx
@@ -1,5 +1,5 @@
 import { createRoutesStub } from 'react-router';
-import Temasider from '~/routes/temasider';
+import Temasider from '~/routes/temasider._index';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, test } from 'vitest';
 import { createValidArticleSummaries } from '../test-data/article';

--- a/test/routes/temasider._index.test.tsx
+++ b/test/routes/temasider._index.test.tsx
@@ -46,6 +46,12 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
     expect(lenke.getAttribute('href')).toBe('/temasider/vin');
   });
 
+  test('Tittellenken strekkes over hele kortet (stretched-link)', async () => {
+    renderListe();
+    const lenke = await screen.findByRole('link', { name: /Vin/ });
+    expect(lenke.classList.contains('stretched-link')).toBe(true);
+  });
+
   test('Tom liste viser en beskjed om at det ikke finnes temasider', async () => {
     renderListe([]);
     await waitFor(() => screen.getByText(/ingen temasider/i));

--- a/test/routes/temasider._index.test.tsx
+++ b/test/routes/temasider._index.test.tsx
@@ -16,6 +16,8 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
           return summaries;
         },
       },
+      // Mål for «ny»-inngangen – mer spesifikk path først, så den vinner over :slug.
+      { path: '/temasider/ny', Component: () => <div>Ny temaside-editor</div> },
       // Mål for lenkene – så vi kan verifisere at hver temaside lenker riktig.
       { path: '/temasider/:slug', Component: () => <div>Temaside-visning</div> },
     ]);
@@ -47,5 +49,17 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
   test('Tom liste viser en beskjed om at det ikke finnes temasider', async () => {
     renderListe([]);
     await waitFor(() => screen.getByText(/ingen temasider/i));
+  });
+
+  test('Har en inngang som lenker til editoren for ny temaside', async () => {
+    renderListe();
+    const lenke = await screen.findByRole('link', { name: /ny temaside/i });
+    expect(lenke.getAttribute('href')).toBe('/temasider/ny');
+  });
+
+  test('Inngangen til ny temaside vises også når lista er tom', async () => {
+    renderListe([]);
+    const lenke = await screen.findByRole('link', { name: /ny temaside/i });
+    expect(lenke.getAttribute('href')).toBe('/temasider/ny');
   });
 });

--- a/test/routes/temasider.ny.test.tsx
+++ b/test/routes/temasider.ny.test.tsx
@@ -2,15 +2,25 @@ import { createRoutesStub } from 'react-router';
 import NyTemaside from '~/routes/temasider.ny';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { afterEach, describe, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(cleanup);
 
 describe('Tester redigeringsverktøy for ny temaside', () => {
   function renderSide() {
-    const Stub = createRoutesStub([{ path: '/temasider/ny', Component: NyTemaside }]);
+    const Stub = createRoutesStub([
+      { path: '/temasider/ny', Component: NyTemaside },
+      // Mål for breadcrumb-lenken tilbake til lista.
+      { path: '/temasider', Component: () => <div>Temaside-lista</div> },
+    ]);
     render(<Stub initialEntries={['/temasider/ny']} />);
   }
+
+  test('Har en breadcrumb-lenke tilbake til temaside-lista', async () => {
+    renderSide();
+    const lenke = await screen.findByRole('link', { name: 'Temasider' });
+    expect(lenke.getAttribute('href')).toBe('/temasider');
+  });
 
   test('Siden viser tittel-felt og innholds-felt', async () => {
     renderSide();

--- a/test/routes/temasider.test.tsx
+++ b/test/routes/temasider.test.tsx
@@ -1,0 +1,51 @@
+import { createRoutesStub } from 'react-router';
+import Temasider from '~/routes/temasider';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, test } from 'vitest';
+import { createValidArticleSummaries } from '../test-data/article';
+
+afterEach(cleanup);
+
+describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
+  function renderListe(summaries = createValidArticleSummaries()) {
+    const Stub = createRoutesStub([
+      {
+        path: '/temasider',
+        Component: Temasider,
+        loader() {
+          return summaries;
+        },
+      },
+      // Mål for lenkene – så vi kan verifisere at hver temaside lenker riktig.
+      { path: '/temasider/:slug', Component: () => <div>Temaside-visning</div> },
+    ]);
+    render(<Stub initialEntries={['/temasider']} />);
+  }
+
+  test('Listen viser tittelen til hver temaside', async () => {
+    renderListe();
+    await waitFor(() => {
+      screen.getByText('Vin');
+      screen.getByText('Hva er en kompilator?');
+    });
+  });
+
+  test('Listen viser forfatteren til hver temaside', async () => {
+    renderListe();
+    await waitFor(() => {
+      screen.getByText('Isak Kyrre Lichtwarck Bjugn');
+      screen.getByText('Ada L.');
+    });
+  });
+
+  test('Hver temaside lenker til sin egen slug', async () => {
+    renderListe();
+    const lenke = await screen.findByRole('link', { name: /Vin/ });
+    expect(lenke.getAttribute('href')).toBe('/temasider/vin');
+  });
+
+  test('Tom liste viser en beskjed om at det ikke finnes temasider', async () => {
+    renderListe([]);
+    await waitFor(() => screen.getByText(/ingen temasider/i));
+  });
+});

--- a/test/test-data/article.ts
+++ b/test/test-data/article.ts
@@ -1,0 +1,21 @@
+import { Article, ArticleSummary } from '~/types/article';
+
+export function createValidArticleSummaries(): ArticleSummary[] {
+  return [
+    { slug: 'vin', title: 'Vin', author: 'Isak Kyrre Lichtwarck Bjugn' },
+    { slug: 'kompilator', title: 'Hva er en kompilator?', author: 'Ada L.' },
+  ];
+}
+
+export function createValidArticle(): Article {
+  return {
+    slug: 'vin',
+    title: 'Vin',
+    content:
+      '# Vin\n\nVinfaget er en av de eldste håndtverkene mennesket har utviklet.\n\n## Rødvin\nEng. *red wine*\n\nRødvin lages på blå eller røde druer.',
+    author: 'Isak Kyrre Lichtwarck Bjugn',
+    updated_by: null,
+    created_at: '2026-06-11T11:10:12.077262Z',
+    updated_at: '2026-06-11T11:10:12.077262Z',
+  };
+}


### PR DESCRIPTION
## Hva

Tar i bruk de nye `/articles`-endepunktene fra Rust-API-et til å vise temasider i frontend:

- **`/temasider`** – liste over alle temasider (henter `GET /articles`), med tittel, forfatter og lenke til hver side. Tom-tilstand når det ikke finnes noen.
- **`/temasider/$slug`** – visning av én temaside (henter `GET /articles/{slug}`), med Markdown-innhold rendret via `react-markdown`, breadcrumb tilbake til lista, og en `ErrorBoundary` med egen 404-visning.
- **Navbar** peker nå på `/temasider` (lista) i stedet for `/temasider/ny`.

## Tilnærming

Testene ble skrevet først (egen «røde tester»-commit), deretter implementasjonen («grønne tester»).

Et par bevisste valg:
- **Tittelen kommer fra selve Markdown-innholdet** (`# Tittel`), ikke som en separat `<h1>`. Dette følger samme mønster som `temasider.ny.tsx`, og unngår dobbel tittel. `title`-feltet brukes til liste, breadcrumb og fanetittel.
- Lista ligger som **indeksrute** (`temasider._index.tsx`), ikke `temasider.tsx`. En `temasider.tsx` ville blitt et layout-foreldre uten `Outlet` og skjult både `/temasider/$slug` og `/temasider/ny`.
- Nye typer er to selvstendige `type`-aliaser (`ArticleSummary`, `Article`) som speiler API-kontrakten. Tidsstempler beholder snake_case slik API-et sender dem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)