### PR TITLE
Innlogging med engangskode (magic code) og sesjons-cookie

### DIFF
--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLoaderData, useLocation, useNavigation } from 'react-router';
+import { NavLink, useLocation, useNavigation, useRouteLoaderData } from 'react-router';
 
 import style from '~/styles/header.module.css';
 
@@ -8,7 +8,11 @@ import FagordLogo from './fagord-logo.svg?react';
 
 export const Header = () => {
   const { search } = useLocation();
-  const { erInnlogget } = useLoaderData();
+  // Header er en delt layout-komponent som også rendres uten root-loaderen (tester,
+  // ruter uten data). `useRouteLoaderData` gir `undefined` i de tilfellene i stedet
+  // for å kaste, så vi faller trygt tilbake på «ikke innlogget».
+  const rootData = useRouteLoaderData<{ erInnlogget: boolean }>('root');
+  const erInnlogget = rootData?.erInnlogget ?? false;
   const navigation = useNavigation();
   const isLoading = navigation.state === 'loading';
 

--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -49,6 +49,11 @@ export const Header = () => {
         <div className="collapse navbar-collapse ms-auto" id="søkefelt">
           <Search />
         </div>
+        <div className="mx-3">
+          <NavLink className="nav-link" to={{ pathname: '/logg-inn' }}>
+            <span className="fa fa-user" />
+          </NavLink>
+        </div>
       </div>
     </nav>
   );

--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -11,12 +11,13 @@ export const Header = () => {
   // Header er en delt layout-komponent som også rendres uten root-loaderen (tester,
   // ruter uten data). `useRouteLoaderData` gir `undefined` i de tilfellene i stedet
   // for å kaste, så vi faller trygt tilbake på «ikke innlogget».
-  const rootData = useRouteLoaderData<{ erInnlogget: boolean }>('root');
-  const erInnlogget = rootData?.erInnlogget ?? false;
+  const rootData = useRouteLoaderData<{ isLoggedIn: boolean }>('root');
+  const isLoggedIn = rootData?.isLoggedIn ?? false;
   const navigation = useNavigation();
   const isLoading = navigation.state === 'loading';
 
-  const userProfileLink = erInnlogget ? '/logg-ut' : '/logg-inn';
+  const userProfileLink = isLoggedIn ? '/logg-ut' : '/logg-inn';
+  const userProfileText = isLoggedIn ? 'Logg ut' : 'Logg inn';
 
   return (
     <nav className="navbar navbar-expand-lg navbar-dark">
@@ -51,15 +52,15 @@ export const Header = () => {
                 </NavLink>
               </li>
             ))}
+            <li className="nav-item" key="user">
+              <NavLink className="nav-link text-nowrap" to={{ pathname: userProfileLink }}>
+                <span className="fa fa-user" /> {userProfileText}
+              </NavLink>
+            </li>
           </ul>
         </div>
         <div className="collapse navbar-collapse ms-auto" id="søkefelt">
           <Search />
-        </div>
-        <div className="mx-3">
-          <NavLink className="nav-link" to={{ pathname: userProfileLink }}>
-            <span className="fa fa-user" />
-          </NavLink>
         </div>
       </div>
     </nav>

--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation, useNavigation } from 'react-router';
+import { NavLink, useLoaderData, useLocation, useNavigation } from 'react-router';
 
 import style from '~/styles/header.module.css';
 
@@ -8,8 +8,11 @@ import FagordLogo from './fagord-logo.svg?react';
 
 export const Header = () => {
   const { search } = useLocation();
+  const { erInnlogget } = useLoaderData();
   const navigation = useNavigation();
   const isLoading = navigation.state === 'loading';
+
+  const userProfileLink = erInnlogget ? '/logg-ut' : '/logg-inn';
 
   return (
     <nav className="navbar navbar-expand-lg navbar-dark">
@@ -50,7 +53,7 @@ export const Header = () => {
           <Search />
         </div>
         <div className="mx-3">
-          <NavLink className="nav-link" to={{ pathname: '/logg-inn' }}>
+          <NavLink className="nav-link" to={{ pathname: userProfileLink }}>
             <span className="fa fa-user" />
           </NavLink>
         </div>

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -1,0 +1,61 @@
+// Sesjonshåndtering for Fagord-appen.
+//
+// `.server.ts`-suffikset garanterer at denne fila aldri havner i klient-bundelen –
+// viktig fordi SESSION_SECRET aldri skal lekke til nettleseren.
+//
+// Den reelle sikkerhetsgrensen er Rust-API-et. Cookien her lagrer bare sesjonstokenet
+// vi fikk fra /auth/verify, signert så det ikke kan forfalskes. På hvert skrivekall
+// sender vi tokenet tilbake som `Authorization: Bearer <token>`, og Rust slår det opp.
+
+import { createCookieSessionStorage } from 'react-router';
+
+const sessionSecret = process.env.SESSION_SECRET;
+
+if (!sessionSecret && process.env.NODE_ENV === 'production') {
+  throw new Error('SESSION_SECRET må være satt i produksjon.');
+}
+
+// Formen på det vi lagrer i cookien. Kun sesjonstokenet foreløpig; navn/e-post kommer
+// når backend utvider /auth/verify-svaret.
+type SesjonData = {
+  token: string;
+};
+
+const { getSession, commitSession, destroySession } = createCookieSessionStorage<SesjonData>({
+  cookie: {
+    name: '__session',
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    secrets: [sessionSecret ?? 'session-secret-dev-only'],
+  },
+});
+
+/** Leser og verifiserer sesjonen fra en innkommende request. */
+export async function hentSesjon(request: Request) {
+  return getSession(request.headers.get('Cookie'));
+}
+
+/** Sant hvis requesten har et sesjonstoken. Brukes til å vise «Logg inn» vs. navn i UI. */
+export async function erInnlogget(request: Request): Promise<boolean> {
+  const session = await hentSesjon(request);
+  return session.has('token');
+}
+
+/**
+ * Oppretter en sesjon: lagrer tokenet i cookien og returnerer en `Set-Cookie`-header.
+ * `expiresAt` er ISO-strengen fra Rust; vi regner om til maxAge (sekunder fra nå).
+ */
+export async function opprettSesjon(request: Request, token: string, expiresAt: string): Promise<string> {
+  const session = await hentSesjon(request);
+  session.set('token', token);
+  const maxAge = Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000);
+  return commitSession(session, { maxAge });
+}
+
+/** Sletter sesjonen. Returnerer en `Set-Cookie`-header som fjerner cookien i nettleseren. */
+export async function loggUt(request: Request): Promise<string> {
+  const session = await hentSesjon(request);
+  return destroySession(session);
+}

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -21,7 +21,11 @@ type SesjonData = {
   token: string;
 };
 
-const { getSession, commitSession, destroySession } = createCookieSessionStorage<SesjonData>({
+const {
+  getSession: getCookieSession,
+  commitSession,
+  destroySession,
+} = createCookieSessionStorage<SesjonData>({
   cookie: {
     name: '__session',
     httpOnly: true,
@@ -33,13 +37,13 @@ const { getSession, commitSession, destroySession } = createCookieSessionStorage
 });
 
 /** Leser og verifiserer sesjonen fra en innkommende request. */
-export async function hentSesjon(request: Request) {
-  return getSession(request.headers.get('Cookie'));
+export async function getSession(request: Request) {
+  return getCookieSession(request.headers.get('Cookie'));
 }
 
 /** Sant hvis requesten har et sesjonstoken. Brukes til å vise «Logg inn» vs. navn i UI. */
-export async function erInnlogget(request: Request): Promise<boolean> {
-  const session = await hentSesjon(request);
+export async function isLoggedIn(request: Request): Promise<boolean> {
+  const session = await getSession(request);
   return session.has('token');
 }
 
@@ -47,15 +51,15 @@ export async function erInnlogget(request: Request): Promise<boolean> {
  * Oppretter en sesjon: lagrer tokenet i cookien og returnerer en `Set-Cookie`-header.
  * `expiresAt` er ISO-strengen fra Rust; vi regner om til maxAge (sekunder fra nå).
  */
-export async function opprettSesjon(request: Request, token: string, expiresAt: string): Promise<string> {
-  const session = await hentSesjon(request);
+export async function createSession(request: Request, token: string, expiresAt: string): Promise<string> {
+  const session = await getSession(request);
   session.set('token', token);
   const maxAge = Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000);
   return commitSession(session, { maxAge });
 }
 
 /** Sletter sesjonen. Returnerer en `Set-Cookie`-header som fjerner cookien i nettleseren. */
-export async function loggUt(request: Request): Promise<string> {
-  const session = await hentSesjon(request);
+export async function logOut(request: Request): Promise<string> {
+  const session = await getSession(request);
   return destroySession(session);
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,9 +6,16 @@ import bootstrapScriptsHref from 'bootstrap/dist/js/bootstrap.bundle.min.js?url'
 import { ErrorMessage } from '~/lib/components/error-message';
 import { Footer } from '~/lib/components/footer';
 import { Header } from '~/lib/components/header';
+import { erInnlogget } from '~/lib/session.server';
 import { splashscreens } from '~/links/splashscreens';
 
+import type { Route } from './+types/root';
 import appStylesHref from './app.css?url';
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  const isLoggedIn = await erInnlogget(request);
+  return { erInnlogget: isLoggedIn };
+};
 
 export function ErrorBoundary() {
   const error = useRouteError();

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,7 +14,7 @@ import appStylesHref from './app.css?url';
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
   const isUserLoggedIn = await isLoggedIn(request);
-  return { erInnlogget: isUserLoggedIn };
+  return { isLoggedIn: isUserLoggedIn };
 };
 
 export function ErrorBoundary() {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,15 +6,15 @@ import bootstrapScriptsHref from 'bootstrap/dist/js/bootstrap.bundle.min.js?url'
 import { ErrorMessage } from '~/lib/components/error-message';
 import { Footer } from '~/lib/components/footer';
 import { Header } from '~/lib/components/header';
-import { erInnlogget } from '~/lib/session.server';
+import { isLoggedIn } from '~/lib/session.server';
 import { splashscreens } from '~/links/splashscreens';
 
 import type { Route } from './+types/root';
 import appStylesHref from './app.css?url';
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
-  const isLoggedIn = await erInnlogget(request);
-  return { erInnlogget: isLoggedIn };
+  const isUserLoggedIn = await isLoggedIn(request);
+  return { erInnlogget: isUserLoggedIn };
 };
 
 export function ErrorBoundary() {

--- a/app/routes/logg-inn.tsx
+++ b/app/routes/logg-inn.tsx
@@ -1,0 +1,147 @@
+import { data, Form, redirect, useActionData, useNavigation } from 'react-router';
+import type { MetaFunction } from 'react-router';
+
+import type { Route } from './+types/logg-inn';
+import { opprettSesjon } from '~/lib/session.server';
+
+export const meta: MetaFunction = () => [{ title: 'Logg inn – Fagord' }];
+
+// Innlogging skjer i to steg i samme rute:
+//   1. «magic»  – be om en engangskode (sendes til e-posten, logges i dev).
+//   2. «verify» – tast inn koden; ved suksess settes sesjons-cookien.
+// Vi skiller stegene med et skjult `intent`-felt framfor to egne ruter. Da følger
+// e-posten fra steg 1 naturlig med inn i steg 2 (skjult felt), uten mellomlagring.
+
+type ActionData = { steg: 'epost' | 'kode'; epost?: string; feil?: string };
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const skjema = await request.formData();
+  const intent = skjema.get('intent');
+  const epost = String(skjema.get('epost') ?? '').trim();
+
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+
+  if (intent === 'magic') {
+    if (!epost) {
+      return data<ActionData>({ steg: 'epost', feil: 'Skriv inn e-postadressen din.' }, { status: 400 });
+    }
+
+    // API-et svarer alltid 202 – også for ukjente e-poster – så vi kan ikke og
+    // skal ikke røpe om adressen finnes. Vi går videre til kode-steget uansett.
+    await fetch(`${FAGORD_RUST_API_URL}/auth/magic`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: epost }),
+    });
+
+    return data<ActionData>({ steg: 'kode', epost });
+  }
+
+  if (intent === 'verify') {
+    const kode = String(skjema.get('kode') ?? '').trim();
+    if (!kode) {
+      return data<ActionData>({ steg: 'kode', epost, feil: 'Skriv inn koden fra e-posten.' }, { status: 400 });
+    }
+
+    const respons = await fetch(`${FAGORD_RUST_API_URL}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: epost, code: kode }),
+    });
+
+    // Alle feil (ukjent e-post, feil/utløpt kode, for mange forsøk) svarer 401.
+    // Vi speiler det med én felles melding – API-et røper med vilje ikke mer.
+    if (!respons.ok) {
+      return data<ActionData>(
+        { steg: 'kode', epost, feil: 'Koden var ugyldig eller utløpt. Prøv igjen.' },
+        { status: 401 },
+      );
+    }
+
+    const { session_token, expires_at } = (await respons.json()) as { session_token: string; expires_at: string };
+    const setCookieHeader = await opprettSesjon(request, session_token, expires_at);
+
+    return redirect('/temasider', {
+      headers: { 'Set-Cookie': setCookieHeader },
+    });
+  }
+
+  return data<ActionData>({ steg: 'epost', feil: 'Ukjent handling.' }, { status: 400 });
+};
+
+export default function LoggInn() {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const sender = navigation.state === 'submitting';
+
+  const påKodesteg = actionData?.steg === 'kode';
+
+  return (
+    <main className="container my-3">
+      <div className="col-12 col-lg-6 mx-auto" style={{ color: 'white' }}>
+        <h1>Logg inn</h1>
+
+        {påKodesteg ? (
+          <>
+            <p>
+              Vi har sendt en engangskode til <strong>{actionData.epost}</strong>. Skriv den inn her for å logge inn.
+            </p>
+            <Form method="post">
+              <input type="hidden" name="intent" value="verify" />
+              <input type="hidden" name="epost" value={actionData.epost} />
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="kode">
+                  Engangskode
+                </label>
+                <input
+                  id="kode"
+                  name="kode"
+                  className={`form-control${actionData?.feil ? ' is-invalid' : ''}`}
+                  type="text"
+                  autoComplete="one-time-code"
+                  autoFocus
+                  required
+                />
+                {actionData?.feil && <div className="invalid-feedback">{actionData.feil}</div>}
+              </div>
+
+              <button className="btn btn-light" disabled={sender}>
+                {sender && <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />}
+                Logg inn
+              </button>
+            </Form>
+          </>
+        ) : (
+          <>
+            <p>Skriv inn e-postadressen din, så sender vi deg en engangskode du taster inn her.</p>
+            <Form method="post">
+              <input type="hidden" name="intent" value="magic" />
+
+              <div className="mb-3">
+                <label className="form-label" htmlFor="epost">
+                  E-post
+                </label>
+                <input
+                  id="epost"
+                  name="epost"
+                  className={`form-control${actionData?.feil ? ' is-invalid' : ''}`}
+                  type="email"
+                  autoComplete="email"
+                  autoFocus
+                  required
+                />
+                {actionData?.feil && <div className="invalid-feedback">{actionData.feil}</div>}
+              </div>
+
+              <button className="btn btn-light" disabled={sender}>
+                {sender && <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />}
+                Send meg en kode
+              </button>
+            </Form>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/routes/logg-inn.tsx
+++ b/app/routes/logg-inn.tsx
@@ -2,7 +2,7 @@ import { data, Form, redirect, useActionData, useNavigation } from 'react-router
 import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/logg-inn';
-import { opprettSesjon } from '~/lib/session.server';
+import { createSession } from '~/lib/session.server';
 
 export const meta: MetaFunction = () => [{ title: 'Logg inn – Fagord' }];
 
@@ -59,7 +59,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
     }
 
     const { session_token, expires_at } = (await respons.json()) as { session_token: string; expires_at: string };
-    const setCookieHeader = await opprettSesjon(request, session_token, expires_at);
+    const setCookieHeader = await createSession(request, session_token, expires_at);
 
     return redirect('/temasider', {
       headers: { 'Set-Cookie': setCookieHeader },
@@ -74,14 +74,14 @@ export default function LoggInn() {
   const navigation = useNavigation();
   const sender = navigation.state === 'submitting';
 
-  const påKodesteg = actionData?.steg === 'kode';
+  const isOnVerifyStep = actionData?.steg === 'kode';
 
   return (
     <main className="container my-3">
       <div className="col-12 col-lg-6 mx-auto" style={{ color: 'white' }}>
         <h1>Logg inn</h1>
 
-        {påKodesteg ? (
+        {isOnVerifyStep ? (
           <>
             <p>
               Vi har sendt en engangskode til <strong>{actionData.epost}</strong>. Skriv den inn her for å logge inn.

--- a/app/routes/logg-ut.tsx
+++ b/app/routes/logg-ut.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router';
 
 import type { Route } from './+types/logg-ut';
-import { hentSesjon, loggUt } from '~/lib/session.server';
+import { getSession, logOut } from '~/lib/session.server';
 
 // Utlogging via loader – kjører på vanlig GET-navigasjon, så header-lenken (en NavLink)
 // treffer den direkte. To ting må skje:
@@ -14,7 +14,7 @@ import { hentSesjon, loggUt } from '~/lib/session.server';
 // til hvis utilsiktet utlogging blir et problem.
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
-  const session = await hentSesjon(request);
+  const session = await getSession(request);
   const token = session.get('token');
 
   // Be Rust invalidere sesjonen. Idempotent og «best effort»: feiler kallet (nettverk,
@@ -31,7 +31,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     }
   }
 
-  const setCookieHeader = await loggUt(request);
+  const setCookieHeader = await logOut(request);
   return redirect('/hjem', {
     headers: { 'Set-Cookie': setCookieHeader },
   });

--- a/app/routes/logg-ut.tsx
+++ b/app/routes/logg-ut.tsx
@@ -1,0 +1,38 @@
+import { redirect } from 'react-router';
+
+import type { Route } from './+types/logg-ut';
+import { hentSesjon, loggUt } from '~/lib/session.server';
+
+// Utlogging via loader – kjører på vanlig GET-navigasjon, så header-lenken (en NavLink)
+// treffer den direkte. To ting må skje:
+//   1. Rust invaliderer sesjonsraden (POST /auth/logout med Bearer-token), slik at
+//      tokenet blir verdiløst selv om noen skulle ha kopiert det.
+//   2. Vi sletter cookien lokalt og sender brukeren til /hjem.
+//
+// Merk: GET er egentlig ikke stedet for tilstandsendringer (prefetch/crawler kan treffe
+// den). En <Form method="post"> mot en action er den strammere løsningen – verdt å bytte
+// til hvis utilsiktet utlogging blir et problem.
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  const session = await hentSesjon(request);
+  const token = session.get('token');
+
+  // Be Rust invalidere sesjonen. Idempotent og «best effort»: feiler kallet (nettverk,
+  // allerede utløpt), logger vi ut lokalt uansett – brukeren skal aldri bli sittende fast.
+  if (token) {
+    const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+    try {
+      await fetch(`${FAGORD_RUST_API_URL}/auth/logout`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch {
+      // Ignorer med vilje – den lokale utloggingen under er det som betyr noe for brukeren.
+    }
+  }
+
+  const setCookieHeader = await loggUt(request);
+  return redirect('/hjem', {
+    headers: { 'Set-Cookie': setCookieHeader },
+  });
+};


### PR DESCRIPTION
## Hva

Legger til innlogging i fagord-appen mot magic-kode-flyten i Rust-API-et. Appen forblir en tynn, tilstandsløs klient: sesjonstokenet fra API-et lagres i en signert, `HttpOnly` cookie, og den ekte sesjonen (og rollen) eier fortsatt Rust.

<img width="557" height="877" alt="image" src="https://github.com/user-attachments/assets/7f004cb5-4486-4921-ab20-2cff676bb5be" />

## Endringer

- **`app/lib/session.server.ts`** – `createCookieSessionStorage` (signert, `HttpOnly`, `Secure` i prod, `SameSite=Lax`). Hjelpere: `hentSesjon`, `isLoggedIn`, `opprettSesjon` (leser `expires_at` fra API-svaret → cookie-`maxAge`), `loggUt`. `.server.ts` holder `SESSION_SECRET` utenfor klient-bundelen.
- **`app/routes/logg-inn.tsx`** – to-stegs skjema i én rute (e-post → engangskode) via skjult `intent`-felt. `POST /auth/magic` svarer alltid 202 (røper ikke om e-post finnes); `POST /auth/verify` gir sesjonstoken som legges i cookien, deretter redirect til `/temasider`.
- **`app/routes/logg-ut.tsx`** – kaller `POST /auth/logout` (best effort) og sletter cookien lokalt.
- **`app/root.tsx`** – root-loader eksponerer `erInnlogget` til layouten.
- **`app/lib/components/header.tsx`** – bruker-ikon som lenker til innlogging/utlogging. Leser status via `useRouteLoaderData('root')` med fallback, så den delte komponenten ikke kaster når root-data mangler.

## Bevisste avgrensninger

- **`krevInnlogget`** for loaders/actions er utsatt til vi kobler på det første skrivekallet (`POST /articles`).
- **Ekte e-post**: koden logges fortsatt server-side i API-et (dev-modus).
- **Navn/e-post i UI** venter på at `/auth/verify`-svaret utvides backend-side.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (33/33) grønt.

## Merk ved deploy

`SESSION_SECRET` **må** settes i produksjon (koden kaster ellers). Dev har en fast fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)