### PR TITLE
Bekreftelsesside for utlogging

### DIFF
--- a/app/routes/logg-ut.tsx
+++ b/app/routes/logg-ut.tsx
@@ -1,19 +1,32 @@
-import { redirect } from 'react-router';
+import { Form, redirect, useNavigation } from 'react-router';
+import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/logg-ut';
-import { getSession, logOut } from '~/lib/session.server';
+import { getSession, isLoggedIn, logOut } from '~/lib/session.server';
 
-// Utlogging via loader – kjører på vanlig GET-navigasjon, så header-lenken (en NavLink)
-// treffer den direkte. To ting må skje:
+export const meta: MetaFunction = () => [{ title: 'Logg ut – Fagord' }];
+
+// Utlogging er en tilstandsendring, og hører derfor hjemme i en `action` (POST), ikke i
+// en `loader` (GET). GET-navigasjon utløses av prefetch, crawlere og nettleserens
+// spekulative henting – da risikerte vi å logge folk ut ved et uhell. Nå er flyten:
+//   1. Header-lenken navigerer hit (GET) → loaderen viser en bekreftelsesside.
+//   2. Brukeren trykker «Logg ut» → <Form method="post"> treffer actionen, som gjør
+//      den faktiske utloggingen.
+
+// GET: er brukeren i det hele tatt innlogget? Hvis ikke har bekreftelsessiden ingen
+// hensikt, og vi sender dem rett til /hjem.
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  if (!(await isLoggedIn(request))) {
+    return redirect('/hjem');
+  }
+  return null;
+};
+
+// POST: selve utloggingen. To ting må skje:
 //   1. Rust invaliderer sesjonsraden (POST /auth/logout med Bearer-token), slik at
 //      tokenet blir verdiløst selv om noen skulle ha kopiert det.
 //   2. Vi sletter cookien lokalt og sender brukeren til /hjem.
-//
-// Merk: GET er egentlig ikke stedet for tilstandsendringer (prefetch/crawler kan treffe
-// den). En <Form method="post"> mot en action er den strammere løsningen – verdt å bytte
-// til hvis utilsiktet utlogging blir et problem.
-
-export const loader = async ({ request }: Route.LoaderArgs) => {
+export const action = async ({ request }: Route.ActionArgs) => {
   const session = await getSession(request);
   const token = session.get('token');
 
@@ -36,3 +49,23 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     headers: { 'Set-Cookie': setCookieHeader },
   });
 };
+
+export default function LoggUt() {
+  const navigation = useNavigation();
+  const sender = navigation.state === 'submitting';
+
+  return (
+    <main className="container my-3">
+      <div className="col-12 col-lg-6 mx-auto" style={{ color: 'white' }}>
+        <h1>Logg ut</h1>
+        <p>Er du sikker på at du vil logge ut?</p>
+        <Form method="post">
+          <button className="btn btn-light" disabled={sender}>
+            {sender && <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />}
+            Logg ut
+          </button>
+        </Form>
+      </div>
+    </main>
+  );
+}

--- a/app/routes/logg-ut.tsx
+++ b/app/routes/logg-ut.tsx
@@ -6,15 +6,6 @@ import { getSession, isLoggedIn, logOut } from '~/lib/session.server';
 
 export const meta: MetaFunction = () => [{ title: 'Logg ut – Fagord' }];
 
-// Utlogging er en tilstandsendring, og hører derfor hjemme i en `action` (POST), ikke i
-// en `loader` (GET). GET-navigasjon utløses av prefetch, crawlere og nettleserens
-// spekulative henting – da risikerte vi å logge folk ut ved et uhell. Nå er flyten:
-//   1. Header-lenken navigerer hit (GET) → loaderen viser en bekreftelsesside.
-//   2. Brukeren trykker «Logg ut» → <Form method="post"> treffer actionen, som gjør
-//      den faktiske utloggingen.
-
-// GET: er brukeren i det hele tatt innlogget? Hvis ikke har bekreftelsessiden ingen
-// hensikt, og vi sender dem rett til /hjem.
 export const loader = async ({ request }: Route.LoaderArgs) => {
   if (!(await isLoggedIn(request))) {
     return redirect('/hjem');
@@ -22,16 +13,10 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   return null;
 };
 
-// POST: selve utloggingen. To ting må skje:
-//   1. Rust invaliderer sesjonsraden (POST /auth/logout med Bearer-token), slik at
-//      tokenet blir verdiløst selv om noen skulle ha kopiert det.
-//   2. Vi sletter cookien lokalt og sender brukeren til /hjem.
 export const action = async ({ request }: Route.ActionArgs) => {
   const session = await getSession(request);
   const token = session.get('token');
 
-  // Be Rust invalidere sesjonen. Idempotent og «best effort»: feiler kallet (nettverk,
-  // allerede utløpt), logger vi ut lokalt uansett – brukeren skal aldri bli sittende fast.
   if (token) {
     const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
     try {
@@ -39,9 +24,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       });
-    } catch {
-      // Ignorer med vilje – den lokale utloggingen under er det som betyr noe for brukeren.
-    }
+    } catch {}
   }
 
   const setCookieHeader = await logOut(request);


### PR DESCRIPTION
## Hva

Utlogging skjer ikke lenger idet brukeren trykker «Logg ut» i headeren. I stedet lander man på en enkel bekreftelsesside, og selve utloggingen skjer først når man bekrefter.

<img width="1129" height="349" alt="image" src="https://github.com/user-attachments/assets/ef36a796-a250-4472-8612-5e2728b30504" />

## Hvorfor

Tidligere gjorde `logg-ut`-ruten utloggingen i en `loader` (GET). GET er feil sted for tilstandsendringer: prefetch, crawlere og nettleserens spekulative henting kan treffe en GET og logge folk ut ved et uhell.

## Endringer

- `loader` (GET) sjekker nå bare at brukeren er innlogget – ellers redirect til `/hjem` – og rendrer bekreftelsessiden.
- Ny `action` (POST) gjør selve utloggingen: Rust-invalidering av sesjonen + sletting av cookie. Logikken er uendret, bare flyttet.
- Ny komponent viser bekreftelsessiden med en `<Form method="post">`, stilt likt `logg-inn.tsx`.

Headeren er urørt: NavLink-en peker fortsatt til `/logg-ut`, men navigasjonen dit er nå en trygg GET som kun *viser* en side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)