### PR TITLE
Lukk mobilmeny ved klientnavigering

### DIFF
--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -20,22 +20,21 @@ declare global {
   }
 }
 
-export const Header = () => {
-  const location = useLocation();
-  const { search } = location;
+const useCloseMenuOnNavigate = (menuId: string) => {
+  const { pathname } = useLocation();
 
-  // Vi bruker IKKE data-bs-toggle på navigasjonslenkene: Bootstrap kaller
-  // preventDefault() på klikk mot <a>-elementer (se collapse.js), noe som ville stoppe
-  // React Routers klientnavigering. I stedet lukker vi mobilmenyen som en effekt av at
-  // ruten faktisk endrer seg. Vi rører den bare når den er åpen (klassen `show`), så på
-  // brede skjermer – der navbar-expand-lg holder menyen åpen uten `show` – gjør vi
-  // ingenting, og unngår collapse-animasjonen som ellers fikk menyen til å blinke.
   useEffect(() => {
-    const meny = document.getElementById('navigasjonsmeny');
+    const meny = document.getElementById(menuId);
     if (meny?.classList.contains('show')) {
       window.bootstrap?.Collapse.getOrCreateInstance(meny).hide();
     }
-  }, [location.pathname]);
+  }, [menuId, pathname]);
+};
+
+export const Header = () => {
+  const { search } = useLocation();
+
+  useCloseMenuOnNavigate('navigasjonsmeny');
 
   // Header er en delt layout-komponent som også rendres uten root-loaderen (tester,
   // ruter uten data). `useRouteLoaderData` gir `undefined` i de tilfellene i stedet

--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { NavLink, useLocation, useNavigation, useRouteLoaderData } from 'react-router';
 
 import style from '~/styles/header.module.css';
@@ -6,8 +7,36 @@ import { navLinks } from '../nav-links';
 import { Search } from './search';
 import FagordLogo from './fagord-logo.svg?react';
 
+// Bootstrap-bundelen (lastet via <script> i root.tsx) legger seg på window.bootstrap.
+// Vi bruker bare Collapse.getOrCreateInstance(...).hide(), så vi typer akkurat det –
+// prosjektet har ikke @types/bootstrap.
+declare global {
+  interface Window {
+    bootstrap?: {
+      Collapse: {
+        getOrCreateInstance: (element: Element) => { hide: () => void };
+      };
+    };
+  }
+}
+
 export const Header = () => {
-  const { search } = useLocation();
+  const location = useLocation();
+  const { search } = location;
+
+  // Vi bruker IKKE data-bs-toggle på navigasjonslenkene: Bootstrap kaller
+  // preventDefault() på klikk mot <a>-elementer (se collapse.js), noe som ville stoppe
+  // React Routers klientnavigering. I stedet lukker vi mobilmenyen som en effekt av at
+  // ruten faktisk endrer seg. Vi rører den bare når den er åpen (klassen `show`), så på
+  // brede skjermer – der navbar-expand-lg holder menyen åpen uten `show` – gjør vi
+  // ingenting, og unngår collapse-animasjonen som ellers fikk menyen til å blinke.
+  useEffect(() => {
+    const meny = document.getElementById('navigasjonsmeny');
+    if (meny?.classList.contains('show')) {
+      window.bootstrap?.Collapse.getOrCreateInstance(meny).hide();
+    }
+  }, [location.pathname]);
+
   // Header er en delt layout-komponent som også rendres uten root-loaderen (tester,
   // ruter uten data). `useRouteLoaderData` gir `undefined` i de tilfellene i stedet
   // for å kaste, så vi faller trygt tilbake på «ikke innlogget».


### PR DESCRIPTION
## Hva

Mobilmenyen (hamburger) lukkes nå automatisk når man navigerer til en ny rute via en av navigasjonslenkene.

## Hvorfor ikke `data-bs-toggle` på lenkene?

Den nærliggende løsningen – å legge `data-bs-toggle="collapse"` på hver navlenke – fungerer ikke: Bootstraps collapse-JS kaller `preventDefault()` på klikk mot `<a>`-elementer (se `collapse.js`), og stopper dermed React Routers klientnavigering. I tillegg kjørte den collapse-animasjonen også på brede skjermer, der `navbar-expand-lg` uansett holder menyen åpen, noe som ga en synlig blinking.

## Løsning

- Lar React Router eie klikket (ingen `data-bs-toggle` på lenkene).
- Ny hook `useCloseMenuOnNavigate(menuId)` lukker menyen som en effekt av at ruten (`pathname`) endrer seg.
- Rører menyen kun når den faktisk er åpen (klassen `show`), så på brede skjermer gjøres ingenting – ingen blinking.

Løsningen degraderer pent uten JS: uten klientruting gir hvert klikk full sidelast, som rendrer headeren på nytt og nullstiller menyen gratis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)