### PR TITLE
Opprett temasider mot API-et, med innloggingsvakt

### DIFF
--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData, useNavigate } from 'react-router';
+import { Link, useLoaderData, useNavigate, useRouteLoaderData } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/temasider._index';
@@ -30,6 +30,10 @@ export function headers(_: Route.HeadersArgs) {
 
 export default function Temasider() {
   const articles = useLoaderData<typeof loader>();
+  // Samme mønster som header.tsx: les innloggingsstatus fra root-loaderen. Vi trenger den
+  // bare for å vise/skjule «Skriv ny»-knappen (ren UX – selve opprettelsen håndheves i Rust).
+  const rootData = useRouteLoaderData<{ isLoggedIn: boolean }>('root');
+  const isLoggedIn = rootData?.isLoggedIn ?? false;
 
   return (
     <main className="container my-3">
@@ -71,11 +75,13 @@ export default function Temasider() {
           </ul>
         )}
 
-        <div className="mt-3">
-          <Link className="btn btn-outline-light" to="ny">
-            Skriv ny temaside
-          </Link>
-        </div>
+        {isLoggedIn && (
+          <div className="mt-3">
+            <Link className="btn btn-outline-light" to="ny">
+              Skriv ny temaside
+            </Link>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/app/routes/temasider.ny.tsx
+++ b/app/routes/temasider.ny.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
-import { Link } from 'react-router';
+import { Form, isRouteErrorResponse, Link, redirect, useRouteError } from 'react-router';
 import type { MetaFunction } from 'react-router';
 import Markdown from 'react-markdown';
 
+import type { Route } from './+types/temasider.ny';
 import style from '~/styles/temasider.module.css';
+import type { Article } from '~/types/article';
+import { getSession } from '~/lib/session.server';
 
 export const meta: MetaFunction = () => [{ title: 'Ny temaside – Fagord' }];
 
@@ -16,6 +19,35 @@ lenker som [denne](/termliste) og punktlister:
 - Andre punkt
 
 Husk: en tom linje gir et nytt avsnitt.`;
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const session = await getSession(request);
+  const token = session.get('token');
+
+  const formData = await request.formData();
+  const tittel = formData.get('tittel');
+  const innhold = formData.get('innhold');
+
+  // Håndhevingen (må være innlogget) ligger i Rust; her sender vi bare med tokenet.
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ title: tittel, content: innhold }),
+  });
+
+  if (!response.ok) {
+    throw new Response('Klarte ikke å opprette temasiden', { status: response.status });
+  }
+
+  // API-et svarer med den opprettede artikkelen; slug-en bruker vi til å gå rett dit.
+  const article = (await response.json()) as Article;
+  return redirect(`/temasider/${article.slug}`);
+};
 
 export default function NyTemaside() {
   const [tittel, setTittel] = useState('');
@@ -34,52 +66,90 @@ export default function NyTemaside() {
         </nav>
 
         <h1>Ny temaside</h1>
-        <p>
-          Skriv artikkelen i Markdown til venstre, og se den ferdige temasiden ta form til høyre mens du skriver.
-          Ingenting lagres ennå – dette er for å bli kjent med formatet.
-        </p>
+        <p>Skriv artikkelen i Markdown til venstre, og se den ferdige temasiden ta form til høyre mens du skriver.</p>
 
-        <div className="mb-3">
-          <label className="form-label" htmlFor="tittel">
-            Tittel
-          </label>
-          <input
-            id="tittel"
-            name="tittel"
-            className="form-control"
-            type="text"
-            value={tittel}
-            onChange={(event) => setTittel(event.target.value)}
-            placeholder="F.eks. Hva er en kompilator?"
-          />
-        </div>
-
-        <div className="row">
-          <div className="col-12 col-lg-6 mb-3">
-            <label className="form-label" htmlFor="innhold">
-              Innhold (Markdown)
+        <Form method="post">
+          <div className="mb-3">
+            <label className="form-label" htmlFor="tittel">
+              Tittel
             </label>
-            <div className={style.scrollBackground}>
-              <textarea
-                id="innhold"
-                name="innhold"
-                className={`form-control ${style.editor}`}
-                value={innhold}
-                onChange={(event) => setInnhold(event.target.value)}
-              />
-            </div>
-            <p className={style.hint}>💡 Tom linje gir nytt avsnitt. Ett enkelt linjeskift slår teksten sammen.</p>
+            <input
+              id="tittel"
+              name="tittel"
+              className="form-control"
+              type="text"
+              value={tittel}
+              onChange={(event) => setTittel(event.target.value)}
+              placeholder="F.eks. Hva er en kompilator?"
+            />
           </div>
 
-          <div className="col-12 col-lg-6 mb-3">
-            <div className="form-label">Forhåndsvisning</div>
-            <article className={style.preview}>
-              {tittel && <h2>{tittel}</h2>}
-              <Markdown>{innhold}</Markdown>
-            </article>
+          <div className="row">
+            <div className="col-12 col-lg-6 mb-3">
+              <label className="form-label" htmlFor="innhold">
+                Innhold (Markdown)
+              </label>
+              <div className={style.scrollBackground}>
+                <textarea
+                  id="innhold"
+                  name="innhold"
+                  className={`form-control ${style.editor}`}
+                  value={innhold}
+                  onChange={(event) => setInnhold(event.target.value)}
+                />
+              </div>
+              <p className={style.hint}>💡 Tom linje gir nytt avsnitt. Ett enkelt linjeskift slår teksten sammen.</p>
+            </div>
+
+            <div className="col-12 col-lg-6 mb-3">
+              <div className="form-label">Forhåndsvisning</div>
+              <article className={style.preview}>
+                {tittel && <h2>{tittel}</h2>}
+                <Markdown>{innhold}</Markdown>
+              </article>
+            </div>
           </div>
-        </div>
+
+          <div className="d-flex gap-2">
+            <button className="btn btn-success" type="submit">
+              Opprett temaside
+            </button>
+            <Link className="btn btn-outline-light" to="/temasider">
+              Avbryt
+            </Link>
+          </div>
+        </Form>
       </div>
     </main>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 401) {
+    return (
+      <div className="container my-3">
+        <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+          <h1>Ikke innlogget</h1>
+          <p>Du må være innlogget for å opprette en temaside. Logg inn og prøv igjen.</p>
+          <Link to="/logg-inn">
+            <button className="btn btn-outline-light">Til innlogging</button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <h1>Her gikk noe galt!</h1>
+        <p>Noe gikk feil mens vi opprettet temasiden. Prøv igjen om litt.</p>
+        <Link to="/temasider">
+          <button className="btn btn-outline-light">Tilbake til temasidene</button>
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/app/routes/temasider.ny.tsx
+++ b/app/routes/temasider.ny.tsx
@@ -6,7 +6,7 @@ import Markdown from 'react-markdown';
 import type { Route } from './+types/temasider.ny';
 import style from '~/styles/temasider.module.css';
 import type { Article } from '~/types/article';
-import { getSession } from '~/lib/session.server';
+import { getSession, isLoggedIn } from '~/lib/session.server';
 
 export const meta: MetaFunction = () => [{ title: 'Ny temaside – Fagord' }];
 
@@ -19,6 +19,16 @@ lenker som [denne](/termliste) og punktlister:
 - Andre punkt
 
 Husk: en tom linje gir et nytt avsnitt.`;
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  // UX-vakt, ikke en sikkerhetsgrense: er du ikke innlogget, kan du uansett ikke lagre.
+  // Da viser vi feilsiden med en gang i stedet for å la brukeren skrive forgjeves.
+  // Rust håndhever det samme på selve POST-kallet.
+  if (!(await isLoggedIn(request))) {
+    throw new Response('Du må være innlogget for å opprette en temaside', { status: 401 });
+  }
+  return null;
+};
 
 export const action = async ({ request }: Route.ActionArgs) => {
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';

--- a/test/routes/temasider._index.test.tsx
+++ b/test/routes/temasider._index.test.tsx
@@ -1,4 +1,4 @@
-import { createRoutesStub } from 'react-router';
+import { createRoutesStub, Outlet } from 'react-router';
 import Temasider from '~/routes/temasider._index';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, test } from 'vitest';
@@ -7,19 +7,29 @@ import { createValidArticleSummaries } from '../test-data/article';
 afterEach(cleanup);
 
 describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
-  function renderListe(summaries = createValidArticleSummaries()) {
+  // Komponenten leser innloggingsstatus fra root-loaderen (useRouteLoaderData('root')),
+  // så vi speiler root som en foreldrerute med id 'root'. Default: innlogget, så
+  // «Skriv ny»-knappen finnes i de fleste testene.
+  function renderListe(summaries = createValidArticleSummaries(), isLoggedIn = true) {
     const Stub = createRoutesStub([
       {
-        path: '/temasider',
-        Component: Temasider,
-        loader() {
-          return summaries;
-        },
+        id: 'root',
+        Component: Outlet,
+        loader: () => ({ isLoggedIn }),
+        children: [
+          {
+            path: '/temasider',
+            Component: Temasider,
+            loader() {
+              return summaries;
+            },
+          },
+          // Mål for «ny»-inngangen – mer spesifikk path først, så den vinner over :slug.
+          { path: '/temasider/ny', Component: () => <div>Ny temaside-editor</div> },
+          // Mål for lenkene – så vi kan verifisere at hver temaside lenker riktig.
+          { path: '/temasider/:slug', Component: () => <div>Temaside-visning</div> },
+        ],
       },
-      // Mål for «ny»-inngangen – mer spesifikk path først, så den vinner over :slug.
-      { path: '/temasider/ny', Component: () => <div>Ny temaside-editor</div> },
-      // Mål for lenkene – så vi kan verifisere at hver temaside lenker riktig.
-      { path: '/temasider/:slug', Component: () => <div>Temaside-visning</div> },
     ]);
     render(<Stub initialEntries={['/temasider']} />);
   }
@@ -69,7 +79,7 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
     await waitFor(() => screen.getByText(/ingen temasider/i));
   });
 
-  test('Har en inngang som lenker til editoren for ny temaside', async () => {
+  test('Innlogget bruker har en inngang som lenker til editoren for ny temaside', async () => {
     renderListe();
     const lenke = await screen.findByRole('link', { name: /ny temaside/i });
     expect(lenke.getAttribute('href')).toBe('/temasider/ny');
@@ -79,5 +89,12 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
     renderListe([]);
     const lenke = await screen.findByRole('link', { name: /ny temaside/i });
     expect(lenke.getAttribute('href')).toBe('/temasider/ny');
+  });
+
+  test('Utlogget bruker ser ikke inngangen til ny temaside', async () => {
+    renderListe(createValidArticleSummaries(), false);
+    // Vent til lista er rendret, så vi vet komponenten faktisk har lastet.
+    await screen.findByText('Vin');
+    expect(screen.queryByRole('link', { name: /ny temaside/i })).toBeNull();
   });
 });

--- a/test/routes/temasider.ny.test.tsx
+++ b/test/routes/temasider.ny.test.tsx
@@ -1,5 +1,6 @@
 import { createRoutesStub } from 'react-router';
-import NyTemaside, { action } from '~/routes/temasider.ny';
+import NyTemaside, { action, ErrorBoundary, loader } from '~/routes/temasider.ny';
+import * as session from '~/lib/session.server';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -45,6 +46,26 @@ describe('Tester redigeringsverktøy for ny temaside', () => {
     await userEvent.clear(editor);
     await userEvent.type(editor, '**fet tekst**');
     await waitFor(() => screen.getByText('fet tekst'));
+  });
+
+  test('Viser feilsiden når brukeren ikke er innlogget', async () => {
+    // Ekte loader + ErrorBoundary. Stubbens request har ingen sesjons-cookie,
+    // så isLoggedIn er falsk og loaderen kaster 401 før skjemaet vises.
+    const Stub = createRoutesStub([{ path: '/temasider/ny', Component: NyTemaside, ErrorBoundary, loader }]);
+    render(<Stub initialEntries={['/temasider/ny']} />);
+
+    await waitFor(() => screen.getByRole('heading', { name: /ikke innlogget/i }));
+    expect(screen.queryByLabelText('Tittel')).toBeNull();
+  });
+
+  test('Loaderen slipper gjennom når brukeren er innlogget', async () => {
+    // Vi tester loaderens forgrening, ikke cookie-mekanismen (den er dekket i
+    // session.server). Derfor stubber vi isLoggedIn til å svare true.
+    vi.spyOn(session, 'isLoggedIn').mockResolvedValue(true);
+    const request = new Request('http://localhost/temasider/ny');
+
+    const result = await loader({ request } as Parameters<typeof loader>[0]);
+    expect(result).toBeNull();
   });
 
   test('Innsending kaller POST /articles og redirecter til den nye temasiden', async () => {

--- a/test/routes/temasider.ny.test.tsx
+++ b/test/routes/temasider.ny.test.tsx
@@ -1,10 +1,13 @@
 import { createRoutesStub } from 'react-router';
-import NyTemaside from '~/routes/temasider.ny';
+import NyTemaside, { action } from '~/routes/temasider.ny';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe('Tester redigeringsverktøy for ny temaside', () => {
   function renderSide() {
@@ -42,5 +45,31 @@ describe('Tester redigeringsverktøy for ny temaside', () => {
     await userEvent.clear(editor);
     await userEvent.type(editor, '**fet tekst**');
     await waitFor(() => screen.getByText('fet tekst'));
+  });
+
+  test('Innsending kaller POST /articles og redirecter til den nye temasiden', async () => {
+    // Ekte action med mocket fetch, så vi verifiserer selve POST-kroppen og redirecten.
+    const fetchMock = vi.fn(
+      async (_url: string, _init: RequestInit) => new Response(JSON.stringify({ slug: 'ny-side' }), { status: 201 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const formData = new FormData();
+    formData.set('tittel', 'Ny side');
+    formData.set('innhold', '# Ny side');
+    const request = new Request('http://localhost/temasider/ny', { method: 'POST', body: formData });
+
+    // action-en bruker kun `request`; vi caster ved grensen siden createRoutesStub/typegen
+    // ellers krever hele args-formen (params, url, pattern ...).
+    const response = await action({ request } as Parameters<typeof action>[0]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/articles$/);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ title: 'Ny side', content: '# Ny side' });
+
+    // redirect() gir en Response med Location-header til den nye slug-en.
+    expect(response.headers.get('Location')).toBe('/temasider/ny-side');
   });
 });


### PR DESCRIPTION
Kobler `temasider.ny.tsx` til `POST /articles`, slik at temasider faktisk lagres i stedet for kun å forhåndsvises. Følger samme mønster som redigeringssiden (`temasider.$slug_.endre.tsx`).

Innlogget:
<img width="1126" height="348" alt="image" src="https://github.com/user-attachments/assets/e1254c73-ddb1-44a1-98ea-2c8aa13eefab" />

Ikke innlogget:
<img width="1141" height="369" alt="image" src="https://github.com/user-attachments/assets/762789a3-53f5-4b98-9a4d-d487c2400df9" />


## Endringer

- **`temasider.ny.tsx`**
  - `action` sender `POST /articles` med Bearer-token og redirecter til den nye temasiden via `slug` fra svaret (samme mønster som `ny-term.legg-til`).
  - `loader` sjekker `isLoggedIn` og kaster **401** med en gang hvis brukeren ikke er innlogget – feilsiden vises umiddelbart, ikke først ved publisering (speiler hvordan endre-siden kaster 403 i sin loader).
  - `<Form method="post">` med «Opprett temaside»- og «Avbryt»-knapper, og `ErrorBoundary` som skiller 401 (ikke innlogget → lenke til `/logg-inn`) fra generell feil.
- **`temasider._index.tsx`** – «Skriv ny temaside»-knappen vises kun for innloggede brukere. Leser `isLoggedIn` fra root-loaderen via `useRouteLoaderData('root')`, samme mønster som `header.tsx` (rutens egen loader-returtype er uendret).

## To lag, begge ren UX

Skjult knapp for det vanlige tilfellet, loader-vakt (401) for direkte navigering til `/temasider/ny`. Den ekte håndhevingen ligger uansett i Rust på `POST`-kallet.

## Testing

- Ny-siden: action kaller `POST /articles` med riktig kropp og redirecter; feilsiden vises når man ikke er innlogget; loaderen slipper gjennom når man er innlogget.
- Lista: utlogget bruker ser ikke «Skriv ny»-knappen; innlogget gjør det (root-loader speiles som foreldrerute med `id: 'root'` i stubben).
- Full suite: 41 tester grønne. Typesjekk og lint passerer.

## Merk

Ikke verifisert mot kjørende backend: antar at `POST /articles` godtar `{ title, content }` og svarer med den opprettede artikkelen inkl. `slug`, og at manglende/utløpt token gir 401 (ikke 403). Bør bekreftes mot Rust-kontrakten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)