### PR TITLE
Slett temaside via egen rute med tilgangsstyring

### DIFF
--- a/app/routes/temasider.$slug_.slett.tsx
+++ b/app/routes/temasider.$slug_.slett.tsx
@@ -1,0 +1,133 @@
+import { Form, isRouteErrorResponse, Link, redirect, useLoaderData, useRouteError } from 'react-router';
+
+import type { Route } from './+types/temasider.$slug_.slett';
+import type { Article } from '~/types/article';
+import { getSession } from '~/lib/session.server';
+
+export const meta = ({ loaderData }: Route.MetaArgs) => [
+  { title: loaderData ? `Slett ${loaderData.title} – Fagord` : 'Slett temaside – Fagord' },
+];
+
+export const loader = async ({ request, params }: Route.LoaderArgs) => {
+  const { slug } = params;
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const session = await getSession(request);
+  const token = session.get('token');
+
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles/${slug}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Response('Temasiden finnes ikke', { status: 404 });
+  }
+
+  const article = (await response.json()) as Article;
+
+  // UX-vakt, ikke en sikkerhetsgrense: API-et regner ut eier/admin og speiler det i
+  // `actions`. Mangler «delete», har brukeren ikke lov til å slette – da stopper vi før
+  // bekreftelsen vises. Rust håndhever uansett det samme på selve DELETE-kallet.
+  if (!article.actions.includes('delete')) {
+    throw new Response('Du har ikke tilgang til å slette denne temasiden', { status: 403 });
+  }
+
+  return article;
+};
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  const { slug } = params;
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const session = await getSession(request);
+  const token = session.get('token');
+
+  // Autorisasjonen (eier ELLER admin) håndheves i Rust; her sender vi bare med tokenet.
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles/${slug}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Response('Klarte ikke å slette temasiden', { status: response.status });
+  }
+
+  return redirect('/temasider');
+};
+
+export default function SlettTemaside() {
+  const article = useLoaderData<typeof loader>();
+
+  return (
+    <main className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link to="/temasider">Temasider</Link>
+            </li>
+            <li className="breadcrumb-item">
+              <Link to={`/temasider/${article.slug}`}>{article.title}</Link>
+            </li>
+            <li className="breadcrumb-item active">Slett</li>
+          </ol>
+        </nav>
+
+        <h1>Slett temaside</h1>
+        <p>
+          Er du sikker på at du vil slette «{article.title}»? Dette kan ikke angres.
+        </p>
+
+        <Form method="post" className="d-flex gap-2">
+          <button className="btn btn-danger" type="submit">
+            Ja, slett temasiden
+          </button>
+          <Link className="btn btn-outline-light" to={`/temasider/${article.slug}`}>
+            Avbryt
+          </Link>
+        </Form>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 403) {
+    return (
+      <div className="container my-3">
+        <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+          <h1>Ingen tilgang</h1>
+          <p>Du kan bare slette temasider du selv har skrevet. Ta kontakt hvis du mener dette er feil.</p>
+          <Link to="/temasider">
+            <button className="btn btn-outline-light">Tilbake til temasidene</button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <div className="container my-3">
+        <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+          <h1>Ops! Her var det ingenting!</h1>
+          <p>Vi fant ikke temasiden du prøvde å slette. Er du sikker på at den finnes?</p>
+          <Link to="/temasider">
+            <button className="btn btn-outline-light">Tilbake til temasidene</button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container my-3">
+      <div className="col-12 col-lg-10 mx-auto" style={{ color: 'white' }}>
+        <h1>Her gikk noe galt!</h1>
+        <p>Noe gikk feil mens vi slettet temasiden. Prøv igjen om litt.</p>
+        <Link to="/temasider">
+          <button className="btn btn-outline-light">Tilbake til temasidene</button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useLoaderData, useNavigate, useNavigation, useRouteLoaderData } from 'react-router';
+import { Link, useLoaderData, useNavigate, useRouteLoaderData } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/temasider._index';
@@ -22,29 +22,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   return (await response.json()) as ArticleSummary[];
 };
 
-export const action = async ({ request }: Route.ActionArgs) => {
-  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
-  const session = await getSession(request);
-  const token = session.get('token');
-
-  const formData = await request.formData();
-  const slug = formData.get('slug');
-
-  // Autorisasjonen (eier ELLER admin) håndheves i Rust; her sender vi bare med tokenet.
-  const response = await fetch(`${FAGORD_RUST_API_URL}/articles/${slug}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  if (!response.ok) {
-    throw new Response('Klarte ikke å slette temasiden', { status: response.status });
-  }
-
-  // Ingen redirect: vi er allerede på listesiden, og React Router laster loaderen
-  // på nytt etter en vellykket action – så den slettede raden forsvinner av seg selv.
-  return null;
-};
-
 export function headers(_: Route.HeadersArgs) {
   return {
     'Cache-Control': 'public, max-age=300, s-maxage=600',
@@ -57,12 +34,6 @@ export default function Temasider() {
   // bare for å vise/skjule «Skriv ny»-knappen (ren UX – selve opprettelsen håndheves i Rust).
   const rootData = useRouteLoaderData<{ isLoggedIn: boolean }>('root');
   const isLoggedIn = rootData?.isLoggedIn ?? false;
-
-  // Mens en sletting pågår vet vi hvilken rad det gjelder via slug-feltet i skjemaet.
-  // Det bruker vi til å deaktivere akkurat den knappen og gi en «Sletter …»-tilstand.
-  const navigation = useNavigation();
-  const slugSomSlettes =
-    navigation.state !== 'idle' ? navigation.formData?.get('slug')?.toString() : undefined;
 
   return (
     <main className="container my-3">
@@ -100,26 +71,14 @@ export default function Temasider() {
                   </Link>
                 )}
                 {article.actions.includes('delete') && (
-                  <Form
-                    method="post"
-                    className="position-relative z-2"
-                    onSubmit={(event) => {
-                      if (!confirm(`Vil du slette «${article.title}»? Dette kan ikke angres.`)) {
-                        event.preventDefault();
-                      }
-                    }}
+                  <Link
+                    className="btn btn-outline-danger btn-sm position-relative z-2 d-flex align-items-center"
+                    to={`${article.slug}/slett`}
+                    aria-label={`Slett ${article.title}`}
+                    title="Slett temaside"
                   >
-                    <input type="hidden" name="slug" value={article.slug} />
-                    <button
-                      className="btn btn-outline-danger btn-sm d-flex align-items-center"
-                      type="submit"
-                      disabled={slugSomSlettes === article.slug}
-                      aria-label={`Slett ${article.title}`}
-                      title="Slett temaside"
-                    >
-                      <span className="fa fa-trash" />
-                    </button>
-                  </Form>
+                    <span className="fa fa-trash" />
+                  </Link>
                 )}
               </li>
             ))}

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData, useNavigate, useRouteLoaderData } from 'react-router';
+import { Form, Link, useLoaderData, useNavigate, useNavigation, useRouteLoaderData } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
 import type { Route } from './+types/temasider._index';
@@ -22,6 +22,29 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   return (await response.json()) as ArticleSummary[];
 };
 
+export const action = async ({ request }: Route.ActionArgs) => {
+  const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
+  const session = await getSession(request);
+  const token = session.get('token');
+
+  const formData = await request.formData();
+  const slug = formData.get('slug');
+
+  // Autorisasjonen (eier ELLER admin) håndheves i Rust; her sender vi bare med tokenet.
+  const response = await fetch(`${FAGORD_RUST_API_URL}/articles/${slug}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Response('Klarte ikke å slette temasiden', { status: response.status });
+  }
+
+  // Ingen redirect: vi er allerede på listesiden, og React Router laster loaderen
+  // på nytt etter en vellykket action – så den slettede raden forsvinner av seg selv.
+  return null;
+};
+
 export function headers(_: Route.HeadersArgs) {
   return {
     'Cache-Control': 'public, max-age=300, s-maxage=600',
@@ -34,6 +57,12 @@ export default function Temasider() {
   // bare for å vise/skjule «Skriv ny»-knappen (ren UX – selve opprettelsen håndheves i Rust).
   const rootData = useRouteLoaderData<{ isLoggedIn: boolean }>('root');
   const isLoggedIn = rootData?.isLoggedIn ?? false;
+
+  // Mens en sletting pågår vet vi hvilken rad det gjelder via slug-feltet i skjemaet.
+  // Det bruker vi til å deaktivere akkurat den knappen og gi en «Sletter …»-tilstand.
+  const navigation = useNavigation();
+  const slugSomSlettes =
+    navigation.state !== 'idle' ? navigation.formData?.get('slug')?.toString() : undefined;
 
   return (
     <main className="container my-3">
@@ -69,6 +98,28 @@ export default function Temasider() {
                   >
                     <span className="fa fa-pencil" />
                   </Link>
+                )}
+                {article.actions.includes('delete') && (
+                  <Form
+                    method="post"
+                    className="position-relative z-2"
+                    onSubmit={(event) => {
+                      if (!confirm(`Vil du slette «${article.title}»? Dette kan ikke angres.`)) {
+                        event.preventDefault();
+                      }
+                    }}
+                  >
+                    <input type="hidden" name="slug" value={article.slug} />
+                    <button
+                      className="btn btn-outline-danger btn-sm d-flex align-items-center"
+                      type="submit"
+                      disabled={slugSomSlettes === article.slug}
+                      aria-label={`Slett ${article.title}`}
+                      title="Slett temaside"
+                    >
+                      <span className="fa fa-trash" />
+                    </button>
+                  </Form>
                 )}
               </li>
             ))}

--- a/app/types/article.ts
+++ b/app/types/article.ts
@@ -21,4 +21,4 @@ export type Article = {
   actions: ArticleAction[];
 };
 
-type ArticleAction = 'edit';
+type ArticleAction = 'edit' | 'delete';

--- a/test/routes/temasider.$slug_.slett.test.tsx
+++ b/test/routes/temasider.$slug_.slett.test.tsx
@@ -1,0 +1,49 @@
+import { createRoutesStub } from 'react-router';
+import SlettTemaside, { ErrorBoundary, loader } from '~/routes/temasider.$slug_.slett';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createArticleWithDeleteAccess, createValidArticle } from '../test-data/article';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// Kjører den EKTE loaderen (ikke en stub som bare kaster), så det er vår actions-sjekk
+// som faktisk testes. `fetch` mockes til å svare med en artikkel – tilgangen avgjøres
+// av om svaret inneholder «delete» i actions.
+function renderMedArtikkel(article: ReturnType<typeof createValidArticle>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify(article), { status: 200 })),
+  );
+
+  const Stub = createRoutesStub([
+    {
+      path: '/temasider/:slug/slett',
+      Component: SlettTemaside,
+      ErrorBoundary,
+      // createRoutesStub kjenner ikke rutens param-form, så vi caster ved grensen.
+      loader: (args) => loader(args as Parameters<typeof loader>[0]),
+    },
+  ]);
+  render(<Stub initialEntries={[`/temasider/${article.slug}/slett`]} />);
+}
+
+describe('Tester tilgangsstyring på slett-siden for temasider', () => {
+  test('Viser feilsiden når brukeren mangler «delete»-tilgang', async () => {
+    // Har «edit», men ikke «delete» – bekrefter at vakten sjekker nettopp «delete».
+    renderMedArtikkel(createValidArticle());
+
+    await waitFor(() => screen.getByRole('heading', { name: /ingen tilgang/i }));
+    // Bekreftelsen skal aldri rendres for en bruker uten tilgang.
+    expect(screen.queryByRole('button', { name: /slett temasiden/i })).toBeNull();
+  });
+
+  test('Viser bekreftelsen når brukeren har «delete»-tilgang', async () => {
+    renderMedArtikkel(createArticleWithDeleteAccess());
+
+    await waitFor(() => screen.getByRole('button', { name: /slett temasiden/i }));
+    expect(screen.queryByRole('heading', { name: /ingen tilgang/i })).toBeNull();
+  });
+});

--- a/test/routes/temasider._index.test.tsx
+++ b/test/routes/temasider._index.test.tsx
@@ -28,6 +28,9 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
           { path: '/temasider/ny', Component: () => <div>Ny temaside-editor</div> },
           // Mål for lenkene – så vi kan verifisere at hver temaside lenker riktig.
           { path: '/temasider/:slug', Component: () => <div>Temaside-visning</div> },
+          // Mål for rediger- og slett-inngangene per rad.
+          { path: '/temasider/:slug/endre', Component: () => <div>Endre-editor</div> },
+          { path: '/temasider/:slug/slett', Component: () => <div>Slett-bekreftelse</div> },
         ],
       },
     ]);
@@ -72,6 +75,18 @@ describe('Tester innhold på og navigasjon fra Temasider-listen', () => {
     renderListe();
     await screen.findByRole('link', { name: 'Hva er en kompilator?' });
     expect(screen.queryByRole('link', { name: /rediger hva er en kompilator/i })).toBeNull();
+  });
+
+  test('Viser slettelenke når temasiden har «delete»-handling', async () => {
+    renderListe();
+    const lenke = await screen.findByRole('link', { name: /slett vin/i });
+    expect(lenke.getAttribute('href')).toBe('/temasider/vin/slett');
+  });
+
+  test('Viser ikke slettelenke uten «delete»-handling', async () => {
+    renderListe();
+    await screen.findByRole('link', { name: 'Hva er en kompilator?' });
+    expect(screen.queryByRole('link', { name: /slett hva er en kompilator/i })).toBeNull();
   });
 
   test('Tom liste viser en beskjed om at det ikke finnes temasider', async () => {

--- a/test/test-data/article.ts
+++ b/test/test-data/article.ts
@@ -2,7 +2,7 @@ import { Article, ArticleSummary } from '~/types/article';
 
 export function createValidArticleSummaries(): ArticleSummary[] {
   return [
-    { slug: 'vin', title: 'Vin', author: 'Isak Kyrre Lichtwarck Bjugn', actions: ['edit'] },
+    { slug: 'vin', title: 'Vin', author: 'Isak Kyrre Lichtwarck Bjugn', actions: ['edit', 'delete'] },
     { slug: 'kompilator', title: 'Hva er en kompilator?', author: 'Ada L.', actions: [] },
   ];
 }
@@ -24,4 +24,9 @@ export function createValidArticle(): Article {
 /** Som en gyldig artikkel, men uten «edit» – dvs. innlogget bruker mangler skrivetilgang. */
 export function createArticleWithoutEditAccess(): Article {
   return { ...createValidArticle(), actions: [] };
+}
+
+/** Artikkel der brukeren har «delete» – dvs. eier eller admin, og kan slette. */
+export function createArticleWithDeleteAccess(): Article {
+  return { ...createValidArticle(), actions: ['delete'] };
 }


### PR DESCRIPTION
## Hva

Legger til mulighet for å slette en temaside, styrt av `delete`-handlingen i `actions`-arrayet fra API-et – samme mønster som `edit` allerede bruker.
<img width="828" height="239" alt="image" src="https://github.com/user-attachments/assets/45bebbc5-0d21-4080-9bb6-b93deb244c9a" />
<img width="1010" height="218" alt="image" src="https://github.com/user-attachments/assets/d80dff5e-0363-4db2-ae10-bfa6948efc0b" />

## Endringer

- **Ny rute `temasider.$slug_.slett.tsx`**: egen bekreftelsesside på `/temasider/<slug>/slett`. `loader` sjekker `actions.includes('delete')` og kaster `403` hvis brukeren mangler tilgang (UX-vakt – Rust håndhever uansett på `DELETE`-kallet). `action` gjør `DELETE`-kallet og redirecter til `/temasider`. Bekreftelsen er et vanlig `<Form>`, så flyten fungerer uten JavaScript.
- **`temasider._index.tsx`**: slette-knapp per rad, vist når temasiden har `delete` i `actions`. Ren `<Link>` til slett-ruten, symmetrisk med rediger-knappen.
- **`types/article.ts`**: `ArticleAction` utvidet med `'delete'`.

## Tester

- Tilgangsvakt på slett-ruten: viser feilside uten `delete`, bekreftelse med `delete`.
- Listen: viser/skjuler slette-lenken avhengig av `delete`-handlingen.
- Alle 45 tester grønne, `pnpm typecheck` og `pnpm lint` rene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)