### PR TITLE
Bytt FontAwesome fra DOM-muterende script til lokal webfont

### DIFF
--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -69,20 +69,20 @@ export const Header = () => {
           data-bs-toggle="collapse"
           data-bs-target="#søkefelt"
         >
-          <span aria-hidden className="fa fa-search" />
+          <span aria-hidden className="fa-solid fa-search" />
         </button>
         <div className="collapse navbar-collapse" id="navigasjonsmeny">
           <ul className="navbar-nav">
             {navLinks.map((navItem) => (
               <li className="nav-item" key={navItem.address}>
                 <NavLink className="nav-link text-nowrap" to={{ pathname: navItem.address, search: search }}>
-                  <span aria-hidden className={'fa fa-lg ' + navItem.icon + ' ' + style.icon} /> {navItem.text}
+                  <span aria-hidden className={'fa-solid fa-lg ' + navItem.icon + ' ' + style.icon} /> {navItem.text}
                 </NavLink>
               </li>
             ))}
             <li className="nav-item" key="user">
               <NavLink className="nav-link text-nowrap" to={{ pathname: userProfileLink }}>
-                <span className="fa fa-user" /> {userProfileText}
+                <span className="fa-solid fa-user" /> {userProfileText}
               </NavLink>
             </li>
           </ul>

--- a/app/lib/components/header.tsx
+++ b/app/lib/components/header.tsx
@@ -69,7 +69,7 @@ export const Header = () => {
           data-bs-toggle="collapse"
           data-bs-target="#søkefelt"
         >
-          <span aria-hidden className="fa-solid fa-search" />
+          <span aria-hidden className="fa-solid fa-magnifying-glass" />
         </button>
         <div className="collapse navbar-collapse" id="navigasjonsmeny">
           <ul className="navbar-nav">

--- a/app/lib/nav-links.ts
+++ b/app/lib/nav-links.ts
@@ -3,7 +3,7 @@ import type { NavItem } from '~/types/nav-item';
 export const navLinks: NavItem[] = [
   {
     address: '/hjem',
-    icon: 'fa-home',
+    icon: 'fa-house',
     text: 'Hjem',
   },
   {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,6 +2,7 @@ import type { LinksFunction, MetaFunction } from 'react-router';
 import { Links, Meta, Outlet, Scripts, useRouteError } from 'react-router';
 import bootstrapStylesHref from 'bootstrap/dist/css/bootstrap.min.css?url';
 import bootstrapScriptsHref from 'bootstrap/dist/js/bootstrap.bundle.min.js?url';
+import fontawesomeStylesHref from '@fortawesome/fontawesome-free/css/all.min.css?url';
 
 import { ErrorMessage } from '~/lib/components/error-message';
 import { Footer } from '~/lib/components/footer';
@@ -37,6 +38,7 @@ export function ErrorBoundary() {
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: bootstrapStylesHref },
+  { rel: 'stylesheet', href: fontawesomeStylesHref },
   { rel: 'stylesheet', href: appStylesHref },
   { rel: 'manifest', href: '/manifest.json' },
   { rel: 'icon', href: '/fagord-favicon.ico' },
@@ -66,7 +68,6 @@ export default function Root() {
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <Meta />
         <Links />
-        <script src="https://kit.fontawesome.com/aff1df517b.js" crossOrigin="anonymous"></script>
       </head>
       <body>
         <Header />

--- a/app/routes/temasider._index.tsx
+++ b/app/routes/temasider._index.tsx
@@ -67,7 +67,7 @@ export default function Temasider() {
                     aria-label={`Rediger ${article.title}`}
                     title="Rediger temaside"
                   >
-                    <span className="fa fa-pencil" />
+                    <span className="fa-solid fa-pencil" />
                   </Link>
                 )}
                 {article.actions.includes('delete') && (
@@ -77,7 +77,7 @@ export default function Temasider() {
                     aria-label={`Slett ${article.title}`}
                     title="Slett temaside"
                   >
-                    <span className="fa fa-trash" />
+                    <span className="fa-solid fa-trash" />
                   </Link>
                 )}
               </li>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "7.3.0",
     "@headlessui/react": "2.2.10",
     "@react-router/node": "7.17.0",
     "@react-router/serve": "7.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fortawesome/fontawesome-free':
+        specifier: 7.3.0
+        version: 7.3.0
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -421,6 +424,10 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fortawesome/fontawesome-free@7.3.0':
+    resolution: {integrity: sha512-Yw4Qa43P6e4Xwh0TwEUkHQNRJInWaqIBo73VJmns3j2AIlZPAvUcR4yGIxCPqPRCgyJ5KIVIalF/I1GxhZ/Kgw==}
+    engines: {node: '>=6'}
 
   '@headlessui/react@2.2.10':
     resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
@@ -2990,6 +2997,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fortawesome/fontawesome-free@7.3.0': {}
 
   '@headlessui/react@2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
## Hva og hvorfor

Ved første sidelast oppsto en React-hydreringsadvarsel (`A tree hydrated but some attributes of the server rendered HTML didn't match`). Årsaken var FontAwesome-kittet som ble lastet via `<script src="https://kit.fontawesome.com/...">` i `root.tsx`. Dette er SVG+JS-varianten, som bruker en `MutationObserver` til å erstatte `<span class="fa ...">` med `<svg>` **før** React rekker å hydrere. Server-HTML og klient-DOM ble dermed ulike.

## Endringer

- **Fjernet det eksterne, DOM-muterende scriptet** fra `<head>` i `root.tsx`.
- **La til `@fortawesome/fontawesome-free` (7.3.0)** som lokal avhengighet, og importerer `all.min.css` via `links`-funksjonen (samme mønster som Bootstrap-CSS-en). CSS-varianten tegner ikoner via `::before` + webfont og muterer ikke DOM-en — hydreringen går rent.
- **Oppdatert all ikonbruk til FA7-syntaks:** `fa fa-*` → `fa-solid fa-*`, samt de FA7-native navnene `fa-search` → `fa-magnifying-glass` og `fa-home` → `fa-house`. Brand-ikonene (`fa-brands`) brukte allerede riktig syntaks.

## Avveininger

- CSS-varianten er mest i tråd med prosjektets «HTML/CSS først»- og «bevisst bruk av biblioteker»-prinsipper: ingen render-blocking tredjeparts-script, ingen ekstern CDN-avhengighet, og reproduserbare bygg.
- Vite henter woff2-fontene fra pakken inn i `build/client/assets/` automatisk, så alt serveres lokalt.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (45 tester)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)