### PR TITLE
Rydd opp i meta-tagger i root.tsx

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -49,7 +49,7 @@ export const links: LinksFunction = () => [
 export const meta: MetaFunction = () => [
   { title: 'Fagord' },
   { name: 'description', content: 'Fagord er din kilde til norske fagtermer.' },
-  { name: 'viewport', content: 'width=device-width; initial-scale=1; viewport-fit=cover' },
+  { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' },
   { name: 'mobile-web-app-capable', content: 'yes' },
   { name: 'apple-mobile-web-app-capable', content: 'yes' },
   { name: 'apple-mobile-web-app-title', content: 'Fagord' },
@@ -62,10 +62,6 @@ export default function Root() {
     <html lang="nb">
       <head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width; initial-scale=1; viewport-fit=cover" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Hva

Retter og forenkler meta-taggene i `app/root.tsx`.

- **Fikser viewport-syntaks:** Byttet semikolon (`;`) til komma (`,`) som separator i `viewport`-innholdet. Semikolon er ikke gyldig separator og ga en advarsel i nettleseren:

  > Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.

- **Fjerner duplisering:** De statiske `<meta>`-taggene for viewport og PWA-innstillinger i `<head>` var duplikater av det som allerede settes i `meta`-funksjonen og rendres via `<Meta />`. Disse er fjernet, så metadataene defineres nå ett sted.

`charSet` beholdes som statisk tag siden den bør stå tidlig i `<head>` før nettleseren tolker resten.

## Testing

- Bekreftet manuelt at nettleseradvarselen er borte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)