### PR TITLE
Fremtidsflagg for React Router v8

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -2,4 +2,7 @@ import type { Config } from '@react-router/dev/config';
 
 export default {
   ssr: true,
+  future: {
+    v8_middleware: true,
+  },
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,5 +4,6 @@ export default {
   ssr: true,
   future: {
     v8_middleware: true,
+    v8_splitRouteModules: true,
   },
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -5,5 +5,6 @@ export default {
   future: {
     v8_middleware: true,
     v8_splitRouteModules: true,
+    v8_viteEnvironmentApi: true,
   },
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,5 +6,6 @@ export default {
     v8_middleware: true,
     v8_splitRouteModules: true,
     v8_viteEnvironmentApi: true,
+    v8_trailingSlashAwareDataRequests: true,
   },
 } satisfies Config;


### PR DESCRIPTION
Tar i bruk fire av fem fremtidsflagg for React Router v8. https://reactrouter.com/upgrading/v7

Venter med `v8_passthroughrequests` ettersom denne faktisk krever endringer.