### PR TITLE
Fremtidsflagg: v8_passThroughRequests

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,8 +2,7 @@ import { redirect } from 'react-router';
 
 import type { Route } from './+types/_index';
 
-export const loader = async ({ request }: Route.LoaderArgs) => {
-  const url = new URL(request.url);
+export const loader = async ({ url }: Route.LoaderArgs) => {
   if (url.pathname === '/') {
     return redirect(`/hjem${url.search}`);
   }

--- a/app/routes/api.termliste.søk.tsx
+++ b/app/routes/api.termliste.søk.tsx
@@ -1,16 +1,14 @@
 import type { Term } from '~/types/term';
 import type { Route } from './+types/api.termliste.søk';
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const { searchParams } = new URL(request.url);
+export async function loader({ url }: Route.LoaderArgs) {
+  if (!url.searchParams.get('q')) return [];
 
-  if (!searchParams.get('q')) return [];
-
-  searchParams.set('limit', '5');
   const apiBase = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
-  const url = new URL('/terms', apiBase);
-  url.search = searchParams.toString();
-  const response = await fetch(url);
+  const rustApiUrl = new URL('/terms', apiBase);
+  rustApiUrl.search = url.search;
+  rustApiUrl.searchParams.set('limit', '5');
+  const response = await fetch(rustApiUrl);
 
   if (!response.ok) {
     throw new Response('Klarte ikke å søke etter termer', { status: 500 });

--- a/app/routes/termliste.tsx
+++ b/app/routes/termliste.tsx
@@ -5,9 +5,8 @@ import { Term } from '~/types/term';
 import { Route } from './+types/termliste';
 import { Subject } from '~/types/subject';
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader({ url }: Route.LoaderArgs) {
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
-  const url = new URL(request.url);
   const q = url.searchParams.get('q');
 
   const termsResponse = await fetch(`${FAGORD_RUST_API_URL}/terms${q ? `?q=${encodeURIComponent(q)}` : ''}`);

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,6 +6,7 @@ export default {
     v8_middleware: true,
     v8_splitRouteModules: true,
     v8_viteEnvironmentApi: true,
+    v8_passThroughRequests: true,
     v8_trailingSlashAwareDataRequests: true,
   },
 } satisfies Config;


### PR DESCRIPTION
Tar i bruk siste fremtidsflagg som mangler, `v8_passThroughRequests`, jf. https://reactrouter.com/upgrading/v7#futurev8_passthroughrequests. Innebærer at vi bytter ut `request` med `url` (som fremdeles inneholder normalisert URL) for tre _loadere_.