### PR TITLE
Term-definisjon som markdown

### DIFF
--- a/app/routes/term.$termId.endre.tsx
+++ b/app/routes/term.$termId.endre.tsx
@@ -34,7 +34,7 @@ export default function Endre() {
       <div className="row">
         <label className="form-label" htmlFor="definition">
           Legg til/endre definisjon
-          <input name="definition" placeholder="Skriv inn definisjon" className="form-control" required={true} />
+          <textarea name="definition" placeholder="Skriv inn definisjon" className="form-control" required={true} />
         </label>
       </div>
       <span className="d-flex gap-2">

--- a/app/routes/term.$termId.endre.tsx
+++ b/app/routes/term.$termId.endre.tsx
@@ -47,10 +47,12 @@ export default function Endre() {
           Legg til/endre definisjon
           <textarea
             name="definition"
+            id="definition"
+            rows={4}
             placeholder="Skriv inn definisjon"
             defaultValue={termData.definition}
             className="form-control"
-            required={true}
+            required
           />
         </label>
       </div>

--- a/app/routes/term.$termId.endre.tsx
+++ b/app/routes/term.$termId.endre.tsx
@@ -29,16 +29,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function Endre() {
-  const termData = useRouteLoaderData<Term>('routes/term.$termId');
-
-  if (!termData)
-    return (
-      <Link to="..">
-        <button type="button" className="btn btn-outline-light">
-          Lukk
-        </button>
-      </Link>
-    );
+  const { definition } = useRouteLoaderData<Term>('routes/term.$termId') as Term;
 
   return (
     <Form method="post">
@@ -50,7 +41,7 @@ export default function Endre() {
             id="definition"
             rows={4}
             placeholder="Skriv inn definisjon"
-            defaultValue={termData.definition}
+            defaultValue={definition}
             className="form-control"
             required
           />

--- a/app/routes/term.$termId.endre.tsx
+++ b/app/routes/term.$termId.endre.tsx
@@ -1,14 +1,12 @@
 import { Form, Link, redirect, useRouteLoaderData } from 'react-router';
 
-import type { ChangeDefinition, Term } from '~/types/term';
+import type { Term } from '~/types/term';
 import type { Route } from './+types/term.$termId.endre';
 
 export async function action({ request, params }: Route.ActionArgs) {
   const formData = await request.formData();
   const { termId } = params;
-  const changeDefinition = Object.fromEntries(
-    Object.entries(Object.fromEntries(formData)).filter(([_, v]) => v !== ''),
-  ) as unknown as ChangeDefinition;
+  const definition = formData.get('definition');
 
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
   const termsApiUrl = `${FAGORD_RUST_API_URL}/terms/${termId}/definition`;
@@ -19,7 +17,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       'Content-Type': 'application/json',
     },
     method: 'POST',
-    body: JSON.stringify(changeDefinition),
+    body: JSON.stringify({ definition }),
   });
 
   if (!res.ok) {

--- a/app/routes/term.$termId.endre.tsx
+++ b/app/routes/term.$termId.endre.tsx
@@ -1,6 +1,6 @@
-import { Form, Link, redirect } from 'react-router';
+import { Form, Link, redirect, useRouteLoaderData } from 'react-router';
 
-import type { ChangeDefinition } from '~/types/term';
+import type { ChangeDefinition, Term } from '~/types/term';
 import type { Route } from './+types/term.$termId.endre';
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -29,12 +29,29 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export default function Endre() {
+  const termData = useRouteLoaderData<Term>('routes/term.$termId');
+
+  if (!termData)
+    return (
+      <Link to="..">
+        <button type="button" className="btn btn-outline-light">
+          Lukk
+        </button>
+      </Link>
+    );
+
   return (
     <Form method="post">
       <div className="row">
         <label className="form-label" htmlFor="definition">
           Legg til/endre definisjon
-          <textarea name="definition" placeholder="Skriv inn definisjon" className="form-control" required={true} />
+          <textarea
+            name="definition"
+            placeholder="Skriv inn definisjon"
+            defaultValue={termData.definition}
+            className="form-control"
+            required={true}
+          />
         </label>
       </div>
       <span className="d-flex gap-2">

--- a/app/routes/term.$termId.tsx
+++ b/app/routes/term.$termId.tsx
@@ -22,6 +22,7 @@ import { ToggleButton } from '~/lib/components/toggle-button';
 import { useToggle } from '~/lib/use-toggle';
 import style from '~/styles/term.module.css';
 import type { Term, Variant } from '~/types/term';
+import Markdown from 'react-markdown';
 
 export const loader = async ({ params }: Route.LoaderArgs) => {
   const { termId } = params;
@@ -97,7 +98,13 @@ const Definition = ({ definition }: DefinitionProps) => {
 
   return (
     <div>
-      <p>{definition || <em>Ingen definisjon tilgjengelig.</em>}</p>
+      {definition ? (
+        <Markdown>{definition}</Markdown>
+      ) : (
+        <p>
+          <em>Ingen definisjon tilgjengelig.</em>
+        </p>
+      )}
       <Outlet />
       {!isEditing && (
         <Link to="endre">

--- a/app/types/term.ts
+++ b/app/types/term.ts
@@ -18,10 +18,6 @@ export interface Variant {
   votes: number;
 }
 
-export interface ChangeDefinition {
-  definition: string;
-}
-
 export interface CreateVariant {
   term: string;
   dialect: 'nb' | 'nn';

--- a/test/routes/term.$termId.endre.test.tsx
+++ b/test/routes/term.$termId.endre.test.tsx
@@ -11,6 +11,7 @@ afterEach(cleanup);
 describe('Tester innsending på Endre-siden', () => {
   test('Sender inn definisjon når Send inn-knappen trykkes på', async () => {
     const termId = 'cortex_sub';
+    const term = createValidTerms().find((term) => term.slug === termId)!;
     const newDefinition = 'Dette er en mer passende definisjon';
 
     const actionSpy = vi.fn(async ({ request }) => {
@@ -21,24 +22,30 @@ describe('Tester innsending på Endre-siden', () => {
     const Stub = createRoutesStub([
       {
         path: `/term/${termId}`,
+        id: 'routes/term.$termId',
         Component: Term,
         loader() {
-          return {
-            terms: createValidTerms(),
-            term: createValidTerms().find((term) => term.slug === termId),
-          };
+          return term;
         },
-      },
-      {
-        path: `/term/${termId}/endre`,
-        Component: Endre,
-        action: actionSpy,
+        children: [
+          {
+            path: 'endre',
+            Component: Endre,
+            action: actionSpy,
+          },
+        ],
       },
     ]);
 
     render(<Stub initialEntries={[`/term/${termId}/endre`]} />);
 
-    await userEvent.type(screen.getByLabelText('Legg til/endre definisjon'), newDefinition);
+    const definitionField = await screen.findByLabelText<HTMLTextAreaElement>('Legg til/endre definisjon');
+
+    // Feltet skal være forhåndsutfylt med termens nåværende definisjon
+    expect(definitionField.value).toBe(term.definition);
+
+    await userEvent.clear(definitionField);
+    await userEvent.type(definitionField, newDefinition);
     await userEvent.click(screen.getByText('Send inn'));
 
     expect(actionSpy).toHaveBeenCalled();


### PR DESCRIPTION
Viser term-definisjon som markdown, og viser nåværende term i redigeringsfeltet.

<img width="1143" height="501" alt="image" src="https://github.com/user-attachments/assets/8e54954f-ffb3-4c80-9b03-a50020717276" />