### PR TITLE
Term-definisjon fra JSON

### DIFF
--- a/app/routes/api.definisjon.ts
+++ b/app/routes/api.definisjon.ts
@@ -1,17 +1,37 @@
 import type { Route } from './+types/api.definisjon';
 
-export async function action({ request }: Route.ActionArgs): Promise<string | null> {
+export type DictionaryDefinition = {
+  definitions: Definition[];
+  source: DictionarySource;
+};
+
+type Definition = {
+  definition: string;
+  translations: string[];
+  examples: string[];
+};
+
+type DictionarySource = {
+  name: string;
+  exactUrl: string;
+};
+
+export async function action({ request }: Route.ActionArgs): Promise<DictionaryDefinition | null> {
   const formData = await request.formData();
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
   const definitionApiUrl = `${FAGORD_RUST_API_URL}/definitions`;
   const { term } = Object.fromEntries(formData) as { term: string };
   const termWithDashes = term.replace(/\s+/g, '-');
 
-  const res = await fetch(`${definitionApiUrl}/${termWithDashes}`);
+  const res = await fetch(`${definitionApiUrl}/${termWithDashes}`, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
 
   if (!res.ok) {
     return null;
   }
 
-  return await res.text();
+  return await res.json();
 }

--- a/app/routes/api.definisjon.ts
+++ b/app/routes/api.definisjon.ts
@@ -1,20 +1,5 @@
 import type { Route } from './+types/api.definisjon';
-
-export type DictionaryDefinition = {
-  definitions: Definition[];
-  source: DictionarySource;
-};
-
-type Definition = {
-  definition: string;
-  translations: string[];
-  examples: string[];
-};
-
-type DictionarySource = {
-  name: string;
-  exactUrl: string;
-};
+import type { DictionaryDefinition } from '~/types/definition';
 
 export async function action({ request }: Route.ActionArgs): Promise<DictionaryDefinition | null> {
   const formData = await request.formData();

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -163,7 +163,7 @@ function Definition({ definition }: Props) {
           <li key={defIndex}>
             <div>
               <strong>{def.definition}</strong>
-              {def.translations.length > 0 && <p>{def.translations.concat()}</p>}
+              {def.translations.length > 0 && <p>{def.translations.join(', ')}</p>}
               {def.examples.length > 0 && (
                 <ul>
                   {def.examples.map((example, exampleIndex) => (

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -8,7 +8,7 @@ import { Subject } from '~/types/subject';
 import { ClientOnly } from '~/lib/client-only';
 import { SubjectsCombobox } from '~/lib/components/subjects-combobox';
 import type { Route } from './+types/ny-term.($term)';
-import type { DictionaryDefinition } from '~/routes/api.definisjon';
+import type { DictionaryDefinition } from '~/types/definition';
 
 export async function loader({ params }: Route.LoaderArgs) {
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -143,7 +143,7 @@ function TermInput({
         onChange={handleChange}
       />
       <div className="invalid-feedback bright-feedback-text">{existsFetcher.data?.validationText}</div>
-      <Definitions definition={definition} />
+      <Definition definition={definition} />
     </>
   );
 }
@@ -152,7 +152,7 @@ type Props = {
   definition: DictionaryDefinition | null;
 };
 
-function Definitions({ definition }: Props) {
+function Definition({ definition }: Props) {
   if (!definition) return null;
 
   return (

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -8,6 +8,7 @@ import { Subject } from '~/types/subject';
 import { ClientOnly } from '~/lib/client-only';
 import { SubjectsCombobox } from '~/lib/components/subjects-combobox';
 import type { Route } from './+types/ny-term.($term)';
+import { DictionaryDefinition } from '~/routes/api.definisjon';
 
 export async function loader({ params }: Route.LoaderArgs) {
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';
@@ -18,12 +19,16 @@ export async function loader({ params }: Route.LoaderArgs) {
     return res.json() as Promise<Subject[]>;
   });
 
-  let definition: string | null = null;
+  let definition: DictionaryDefinition | null = null;
   if (params.term) {
     const termWithDashes = params.term.replace(/\s+/g, '-');
-    const res = await fetch(`${FAGORD_RUST_API_URL}/definitions/${termWithDashes}`);
+    const res = await fetch(`${FAGORD_RUST_API_URL}/definitions/${termWithDashes}`, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
     if (res.ok) {
-      definition = await res.text();
+      definition = await res.json();
     }
   }
 
@@ -111,10 +116,10 @@ function TermInput({
   loaderDefinition,
 }: {
   defaultValue: string | undefined;
-  loaderDefinition: string | null;
+  loaderDefinition: DictionaryDefinition | null;
 }) {
   const existsFetcher = useDebounceFetcher<{ exists: boolean; validationText: string | undefined }>();
-  const definitionFetcher = useDebounceFetcher<string | null>();
+  const definitionFetcher = useDebounceFetcher<DictionaryDefinition | null>();
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const formData = new FormData();
@@ -124,7 +129,7 @@ function TermInput({
     definitionFetcher.submit(formData, { method: 'post', action: '/api/definisjon', debounceTimeout: 300 });
   }
 
-  const definitions = definitionFetcher.data !== undefined ? definitionFetcher.data : loaderDefinition;
+  const definition = definitionFetcher.data !== undefined ? definitionFetcher.data : loaderDefinition;
 
   return (
     <>
@@ -138,22 +143,49 @@ function TermInput({
         onChange={handleChange}
       />
       <div className="invalid-feedback bright-feedback-text">{existsFetcher.data?.validationText}</div>
-      <Definitions definitions={definitions} />
+      <Definitions definition={definition} />
     </>
   );
 }
 
 type Props = {
-  definitions: string | null | undefined;
+  definition: DictionaryDefinition | null;
 };
 
-function Definitions({ definitions }: Props) {
-  if (!definitions) return null;
+function Definitions({ definition }: Props) {
+  if (!definition) return null;
 
   return (
     <div className="mt-2">
       <p>Definisjon</p>
-      <div dangerouslySetInnerHTML={{ __html: definitions }} />
+      <ul>
+        {definition.definitions.map((def) => (
+          <li key={def.definition}>
+            <div>
+              <strong>{def.definition}</strong>
+              {def.translations.length > 0 && <p>{def.translations.concat()}</p>}
+              {def.examples.length > 0 && (
+                <ul>
+                  {def.examples.map((example) => (
+                    <li key={example}>{example}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <span>
+        Kilde:{' '}
+        <a
+          className={styles.dictionarySource}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={definition.source.exactUrl}
+        >
+          {definition.source.name}
+        </a>
+      </span>
     </div>
   );
 }

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -159,15 +159,15 @@ function Definition({ definition }: Props) {
     <div className="mt-2">
       <p>Definisjon</p>
       <ul>
-        {definition.definitions.map((def) => (
-          <li key={def.definition}>
+        {definition.definitions.map((def, defIndex) => (
+          <li key={defIndex}>
             <div>
               <strong>{def.definition}</strong>
               {def.translations.length > 0 && <p>{def.translations.concat()}</p>}
               {def.examples.length > 0 && (
                 <ul>
-                  {def.examples.map((example) => (
-                    <li key={example}>{example}</li>
+                  {def.examples.map((example, exampleIndex) => (
+                    <li key={exampleIndex}>{example}</li>
                   ))}
                 </ul>
               )}

--- a/app/routes/ny-term.($term).tsx
+++ b/app/routes/ny-term.($term).tsx
@@ -8,7 +8,7 @@ import { Subject } from '~/types/subject';
 import { ClientOnly } from '~/lib/client-only';
 import { SubjectsCombobox } from '~/lib/components/subjects-combobox';
 import type { Route } from './+types/ny-term.($term)';
-import { DictionaryDefinition } from '~/routes/api.definisjon';
+import type { DictionaryDefinition } from '~/routes/api.definisjon';
 
 export async function loader({ params }: Route.LoaderArgs) {
   const FAGORD_RUST_API_URL = process.env.FAGORD_RUST_API_DOMAIN || 'http://localhost:8080';

--- a/app/styles/ny-term.module.css
+++ b/app/styles/ny-term.module.css
@@ -25,3 +25,7 @@
 :global(.form-control.is-invalid) {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23e57316'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23e57316' stroke='none'/%3e%3c/svg%3e");
 }
+
+.dictionarySource {
+  color: var(--color-light-blue);
+}

--- a/app/types/definition.ts
+++ b/app/types/definition.ts
@@ -1,0 +1,15 @@
+export type DictionaryDefinition = {
+  definitions: Definition[];
+  source: DictionarySource;
+};
+
+type Definition = {
+  definition: string;
+  translations: string[];
+  examples: string[];
+};
+
+type DictionarySource = {
+  name: string;
+  exactUrl: string;
+};

--- a/test/routes/ny-term.($term).test.tsx
+++ b/test/routes/ny-term.($term).test.tsx
@@ -138,6 +138,38 @@ describe('Tester innsending på Ny term-siden', () => {
     expect(screen.getByText('a written message')).toBeDefined();
   });
 
+  test('Fjerner definisjon fra sidelast når søket ikke gir treff', async () => {
+    const termFromUrl = 'letter';
+
+    const Stub = createRoutesStub([
+      {
+        path: '/ny-term/:term',
+        Component: NyTerm,
+        loader: () => ({
+          subjects: createValidSubjects(),
+          definition: createValidDefinition(),
+        }),
+      },
+      {
+        path: '/api/definisjon',
+        action: () => null,
+      },
+      {
+        path: '/api/termliste/finnes',
+        action: () => ({ exists: false, validationText: undefined }),
+      },
+    ]);
+
+    render(<Stub initialEntries={[`/ny-term/${termFromUrl}`]} />);
+
+    await waitFor(() => screen.findByText('Engelsk term'));
+    expect(screen.getByText('a written message')).toBeDefined();
+
+    await userEvent.type(screen.getByDisplayValue(termFromUrl), 'x');
+    await waitFor(() => expect(screen.queryByText('a written message')).toBeNull());
+    expect(screen.queryByText('Definisjon')).toBeNull();
+  });
+
   test('Viser valideringstekst når term allerede finnes', async () => {
     const existingTerm = 'existence';
     const validationText = 'Termen finnes allerede i termlista.';

--- a/test/routes/ny-term.($term).test.tsx
+++ b/test/routes/ny-term.($term).test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import Endre from '~/routes/term.$termId.endre';
 import NyTerm from '~/routes/ny-term.($term)';
 import { createValidSubjects } from '../test-data/subjects';
+import { createValidDefinition } from '../test-data/definition';
 
 afterEach(cleanup);
 
@@ -80,7 +81,7 @@ describe('Tester innsending på Ny term-siden', () => {
 
   test('Viser definisjon ved sidelast når term er i URL', async () => {
     const termFromUrl = 'letter';
-    const definition = '<p>a written message</p>';
+    const definition = createValidDefinition();
 
     const Stub = createRoutesStub([
       {
@@ -98,10 +99,15 @@ describe('Tester innsending på Ny term-siden', () => {
     await waitFor(() => screen.findByText('Engelsk term'));
     expect(screen.getByText('Definisjon')).toBeDefined();
     expect(screen.getByText('a written message')).toBeDefined();
+    expect(screen.getByText('brev, skriv')).toBeDefined();
+    expect(screen.getByText('a letter to the editor')).toBeDefined();
+
+    const source = screen.getByRole('link', { name: 'Ordbøkene' });
+    expect(source.getAttribute('href')).toBe('https://ordbokene.no/nno/bm/letter');
   });
 
   test('Viser definisjon etter at brukeren skriver inn en engelsk term', async () => {
-    const definition = '<p>a written message</p>';
+    const definition = createValidDefinition();
 
     const Stub = createRoutesStub([
       {

--- a/test/test-data/definition.ts
+++ b/test/test-data/definition.ts
@@ -1,0 +1,17 @@
+import type { DictionaryDefinition } from '~/routes/api.definisjon';
+
+export function createValidDefinition(): DictionaryDefinition {
+  return {
+    definitions: [
+      {
+        definition: 'a written message',
+        translations: ['brev', 'skriv'],
+        examples: ['a letter to the editor', 'she wrote him a letter'],
+      },
+    ],
+    source: {
+      name: 'Ordbøkene',
+      exactUrl: 'https://ordbokene.no/nno/bm/letter',
+    },
+  };
+}

--- a/test/test-data/definition.ts
+++ b/test/test-data/definition.ts
@@ -1,4 +1,4 @@
-import type { DictionaryDefinition } from '~/routes/api.definisjon';
+import type { DictionaryDefinition } from '~/types/definition';
 
 export function createValidDefinition(): DictionaryDefinition {
   return {


### PR DESCRIPTION
Viser term-definisjon og kilde med lenke basert på JSON-respons fra `fagord-rust-api`:
<img width="597" height="339" alt="image" src="https://github.com/user-attachments/assets/4a9bdcc9-cf4d-4572-9c99-3e3f44d9772e" />
